### PR TITLE
fix: improve error response when unauthorized

### DIFF
--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -47,12 +47,16 @@ func (s *OAuthService) RefreshToken(ctx context.Context, oldTokenSet *credential
 
 	resp, err := httpClient.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("token refresh failed: %w", err)
+		return nil, fmt.Errorf("graphql request failed: %w", err)
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode == http.StatusUnauthorized {
+		return nil, errors.New("graphql response: unauthorized (401) - you have been logged out. " +
+			"Please login using `cre login` and retry your command")
+	}
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("token refresh failed: %s", resp.Status)
+		return nil, fmt.Errorf("graphql response: %s", resp.Status)
 	}
 
 	var tr struct {


### PR DESCRIPTION
[DEVSVCS-2479](https://smartcontract-it.atlassian.net/browse/DEVSVCS-2479)

This pull request updates the error handling in the OAuth token refresh logic to provide clearer and more actionable error messages, especially for authentication failures. The main change is to improve the feedback given to users when their token refresh request fails due to authorization issues.

Improvements to error handling and user messaging:

* In `internal/auth/service.go`, the error message returned for a failed token refresh now explicitly tells users to log in again if they receive a 401 Unauthorized response, making it clearer what action needs to be taken.
* All error messages related to token refresh failures have been updated to refer to "graphql request/response" for consistency and clarity.

[DEVSVCS-2479]: https://smartcontract-it.atlassian.net/browse/DEVSVCS-2479?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ