### PR TITLE
Update TypeScript cre init to use @chainlink/cre-sdk npm package

### DIFF
--- a/cmd/creinit/template/workflow/typescriptSimpleExample/global.d.ts.tpl
+++ b/cmd/creinit/template/workflow/typescriptSimpleExample/global.d.ts.tpl
@@ -1,1 +1,0 @@
-import "cre-sdk-typescript/src/sdk/types/global.d.ts";

--- a/cmd/creinit/template/workflow/typescriptSimpleExample/main.ts.tpl
+++ b/cmd/creinit/template/workflow/typescriptSimpleExample/main.ts.tpl
@@ -1,6 +1,4 @@
-import { cre } from "cre-sdk-typescript/src/sdk/cre";
-import { Value } from "cre-sdk-typescript/src/sdk/utils/values/value";
-import type { Runtime } from "cre-sdk-typescript/src/sdk/runtime/runtime";
+import { cre, Value, type Runtime } from "@chainlink/cre-sdk";
 
 type Config = {
   schedule: string;

--- a/cmd/creinit/template/workflow/typescriptSimpleExample/package.json.tpl
+++ b/cmd/creinit/template/workflow/typescriptSimpleExample/package.json.tpl
@@ -4,11 +4,11 @@
   "main": "dist/main.js",
   "private": true,
   "scripts": {
-    "build:all": "bun run ./node_modules/cre-sdk-typescript/scripts/build-for-cli.ts"
+    "postinstall": "bunx cre-setup"
   },
   "license": "UNLICENSED",
   "dependencies": {
-    "cre-sdk-typescript": "github:smartcontractkit/cre-sdk-typescript#18e7bbd"
+    "@chainlink/cre-sdk": "0.0.1"
   },
   "devDependencies": {
     "@types/bun": "1.2.21",

--- a/cmd/creinit/template/workflow/typescriptSimpleExample/tsconfig.json.tpl
+++ b/cmd/creinit/template/workflow/typescriptSimpleExample/tsconfig.json.tpl
@@ -9,7 +9,6 @@
     "forceConsistentCasingInFileNames": true
   },
   "include": [
-    "global.d.ts",
     "main.ts"
   ]
 }

--- a/cmd/workflow/simulate/simulate.go
+++ b/cmd/workflow/simulate/simulate.go
@@ -176,8 +176,8 @@ func (h *handler) Execute(inputs Inputs) error {
 	var buildCmd *exec.Cmd
 	if isTypescriptWorkflow {
 		buildCmd = exec.Command(
-			"bun",
-			"build:all",
+			"bunx",
+			"cre-compile",
 			"--input", workflowMainFile,
 			"--output", tmpWasmFileName,
 		)


### PR DESCRIPTION
This is in draft for as long as we can actually depoly the package.