### PR TITLE
Update cre-sdk, for TypeScript workflows, to 0.0.2-alpha

### DIFF
--- a/cmd/creinit/template/workflow/typescriptSimpleExample/main.ts.tpl
+++ b/cmd/creinit/template/workflow/typescriptSimpleExample/main.ts.tpl
@@ -1,30 +1,29 @@
-import { cre, Value, type Runtime } from "@chainlink/cre-sdk";
+import { cre, Runner, type Runtime } from "@chainlink/cre-sdk";
 
 type Config = {
   schedule: string;
 };
 
-function onCronTrigger(_config: Config, runtime: Runtime) {
-  runtime.logger.log("Hello world! Workflow triggered.");
-  cre.sendResponseValue(new Value("Hello world!"));
+const onCronTrigger = (_runtime: Runtime<Config>): string => {
+  console.log("Hello world! Workflow triggered.");
+  return "Hello world!";
 };
 
-function initWorkflow(config: Config) {
+const initWorkflow = (config: Config) => {
   const cron = new cre.capabilities.CronCapability();
 
   return [
     cre.handler(
-      cron.trigger({
-        schedule: config.schedule,
-      }),
+      cron.trigger(
+        { schedule: config.schedule }
+      ), 
       onCronTrigger
     ),
   ];
 };
 
 export async function main() {
-  const runner = await cre.newRunner();
-
+  const runner = await Runner.newRunner<Config>();
   await runner.run(initWorkflow);
 }
 

--- a/cmd/creinit/template/workflow/typescriptSimpleExample/package.json.tpl
+++ b/cmd/creinit/template/workflow/typescriptSimpleExample/package.json.tpl
@@ -8,7 +8,7 @@
   },
   "license": "UNLICENSED",
   "dependencies": {
-    "@chainlink/cre-sdk": "0.0.1-alpha"
+    "@chainlink/cre-sdk": "0.0.2-alpha"
   },
   "devDependencies": {
     "@types/bun": "1.2.21",


### PR DESCRIPTION
Updates TypeScript template to point to new version of the sdk we've published.