### PR TITLE
Enable local evm RPCs

### DIFF
--- a/cmd/workflow/simulate/capabilities.go
+++ b/cmd/workflow/simulate/capabilities.go
@@ -56,10 +56,11 @@ func NewManualTriggerCapabilities(
 	// EVM
 	evmChains := make(map[uint64]*fakes.FakeEVMChain)
 	for sel, client := range cfg.Clients {
+		// Forwarder is optional in simulator mode. If not provided, continue with zero address.
 		fwd, ok := cfg.Forwarders[sel]
 		if !ok {
-			lggr.Infow("Forwarder not found for chain", "selector", sel)
-			continue
+			lggr.Infow("Forwarder not configured for chain; continuing with zero address", "selector", sel)
+			fwd = common.Address{} // zero addr
 		}
 
 		evm := fakes.NewFakeEvmChain(


### PR DESCRIPTION
Sometimes a user may prefer to run _simulate_ mode against running local chain. This PR enables that.

So having a project file like:
```
# Global target configuration. Update the RPC URL with your own endpoint.
local-simulation:
  rpcs:
    - chain-selector: 3379446385462418246
      chain-name: "geth-testnet"
      url: http://127.0.0.1:8545
```

One can run against it wrokflows simulations like so:
```bash
~/cre workflow simulate --target local-simulation --config config.json --broadcast  main_wasm.go --evm-tx-hash 0x84b9f063271df0cd494db661f1e1e97e86a3f0d5e5d4b218f761a3d178664616 --evm-event-index 0 --non-interactive --trigger-index 0 --secrets ./secrets.yaml
```