### PR TITLE
Update TS sdk to 0.0.3-alpha

### DIFF
--- a/cmd/creinit/template/workflow/typescriptSimpleExample/main.ts.tpl
+++ b/cmd/creinit/template/workflow/typescriptSimpleExample/main.ts.tpl
@@ -4,8 +4,8 @@ type Config = {
   schedule: string;
 };
 
-const onCronTrigger = (_runtime: Runtime<Config>): string => {
-  console.log("Hello world! Workflow triggered.");
+const onCronTrigger = (runtime: Runtime<Config>): string => {
+  runtime.log("Hello world! Workflow triggered.");
   return "Hello world!";
 };
 

--- a/cmd/creinit/template/workflow/typescriptSimpleExample/package.json.tpl
+++ b/cmd/creinit/template/workflow/typescriptSimpleExample/package.json.tpl
@@ -8,7 +8,7 @@
   },
   "license": "UNLICENSED",
   "dependencies": {
-    "@chainlink/cre-sdk": "0.0.2-alpha"
+    "@chainlink/cre-sdk": "0.0.3-alpha"
   },
   "devDependencies": {
     "@types/bun": "1.2.21",


### PR DESCRIPTION
- Updates sdk version to [0.0.3-alpha](https://www.npmjs.com/package/@chainlink/cre-sdk) for new `cre init` projects
- Update example to leverage `runtime.log` instead of `console.log`