### PR TITLE
chore: add graphql client logging

### DIFF
--- a/cmd/account/link_key/link_key.go
+++ b/cmd/account/link_key/link_key.go
@@ -215,7 +215,7 @@ mutation InitiateLinking($request: InitiateLinkingRequest!) {
 		InitiateLinking initiateLinkingResponse `json:"initiateLinking"`
 	}
 
-	if err := graphqlclient.New(h.credentials, h.environmentSet).
+	if err := graphqlclient.New(h.credentials, h.environmentSet, h.log).
 		Execute(ctx, req, &container); err != nil {
 		return initiateLinkingResponse{}, fmt.Errorf("graphql request failed: %w", err)
 	}

--- a/cmd/account/list_key/list_key.go
+++ b/cmd/account/list_key/list_key.go
@@ -72,7 +72,7 @@ func NewHandler(ctx *runtime.Context) *Handler {
 		log:            ctx.Logger,
 		credentials:    ctx.Credentials,
 		environmentSet: ctx.EnvironmentSet,
-		client:         graphqlclient.New(ctx.Credentials, ctx.EnvironmentSet),
+		client:         graphqlclient.New(ctx.Credentials, ctx.EnvironmentSet, ctx.Logger),
 	}
 }
 

--- a/cmd/account/unlink_key/unlink_key.go
+++ b/cmd/account/unlink_key/unlink_key.go
@@ -179,7 +179,7 @@ mutation InitiateUnlinking($request: InitiateUnlinkingRequest!) {
 	var container struct {
 		InitiateUnlinking initiateUnlinkingResponse `json:"initiateUnlinking"`
 	}
-	if err := graphqlclient.New(h.credentials, h.environmentSet).Execute(ctx, req, &container); err != nil {
+	if err := graphqlclient.New(h.credentials, h.environmentSet, h.log).Execute(ctx, req, &container); err != nil {
 		return initiateUnlinkingResponse{}, fmt.Errorf("graphql failed: %w", err)
 	}
 

--- a/cmd/whoami/whoami.go
+++ b/cmd/whoami/whoami.go
@@ -62,7 +62,7 @@ func NewHandler(ctx *runtime.Context) *Handler {
 }
 
 func (h *Handler) Execute(ctx context.Context) error {
-	client := graphqlclient.New(h.credentials, h.environmentSet)
+	client := graphqlclient.New(h.credentials, h.environmentSet, h.log)
 	req := graphql.NewRequest(queryGetAccountDetails)
 
 	var respEnvelope struct {

--- a/cmd/workflow/deploy/artifacts.go
+++ b/cmd/workflow/deploy/artifacts.go
@@ -20,7 +20,7 @@ func (h *handler) UploadArtifacts() error {
 		UnsignedGetUrl: "",
 	}
 
-	gql := graphqlclient.New(h.credentials, h.environmentSet)
+	gql := graphqlclient.New(h.credentials, h.environmentSet, h.log)
 
 	chainSelector, err := settings.GetChainSelectorByChainName(h.environmentSet.WorkflowRegistryChainName)
 	if err != nil {

--- a/internal/client/graphqlclient/graphqlclient.go
+++ b/internal/client/graphqlclient/graphqlclient.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	"github.com/machinebox/graphql"
+	"github.com/rs/zerolog"
 
 	"github.com/smartcontractkit/cre-cli/internal/auth"
 	"github.com/smartcontractkit/cre-cli/internal/credentials"
@@ -18,10 +19,13 @@ type Client struct {
 	transport *headerTransport
 }
 
-func New(creds *credentials.Credentials, environmentSet *environments.EnvironmentSet) *Client {
+func New(creds *credentials.Credentials, environmentSet *environments.EnvironmentSet, l *zerolog.Logger) *Client {
 	ht := newHeaderTransport(creds, auth.NewOAuthService(environmentSet), http.DefaultTransport)
 	httpClient := &http.Client{Transport: ht}
 	gqlClient := graphql.NewClient(environmentSet.GraphQLURL, graphql.WithHTTPClient(httpClient))
+	gqlClient.Log = func(s string) {
+		l.Debug().Str("client", "GraphQL").Msg(s)
+	}
 
 	return &Client{
 		client:    gqlClient,


### PR DESCRIPTION
This pull request updates the construction of the `graphqlclient.Client` throughout the codebase to support logging via zerolog. The main change is that a logger is now passed to the `graphqlclient.New` constructor, enabling debug logging for GraphQL client operations. This affects several command handlers and the client implementation itself.

**GraphQL client logging integration:**

* Updated the `graphqlclient.New` constructor in `internal/client/graphqlclient/graphqlclient.go` to accept a `*zerolog.Logger` parameter and set up debug logging for GraphQL client operations. [[1]](diffhunk://#diff-011e4af162aa6025974b73e171398cebf67292dad93e6ccf8655be2ff0d09ea6R9) [[2]](diffhunk://#diff-011e4af162aa6025974b73e171398cebf67292dad93e6ccf8655be2ff0d09ea6L21-R28)
* Refactored all usages of `graphqlclient.New` in command handlers (`cmd/account/link_key/link_key.go`, `cmd/account/list_key/list_key.go`, `cmd/account/unlink_key/unlink_key.go`, `cmd/whoami/whoami.go`, `cmd/workflow/deploy/artifacts.go`) to pass the appropriate logger instance. [[1]](diffhunk://#diff-fdf49ac336cad0cfbf2bd3af1434d59da239660c8c8946a5630c7407cf0d2e3eL218-R218) [[2]](diffhunk://#diff-c70622bc73b4ed3d05afaaba2a895f9520bf4956f276d347845da88f6b82721fL75-R75) [[3]](diffhunk://#diff-6af653134fb50bf9989d877bd6b0f9ba687739d3d795ce6b9d2e0b293ed7ae31L182-R182) [[4]](diffhunk://#diff-c43c6d7741df44792d2add826355ca859bb67c029ec937fa557f937c37437a8dL65-R65) [[5]](diffhunk://#diff-11d9dec72f41a6f0dd2860c50e06414f4a9a8e2b08d5b3c3cfcb2098537c004aL23-R23)