### PR TITLE
feat: add login gating

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -76,12 +76,14 @@ func newRootCommand() *cobra.Command {
 				}
 			}
 
-			err := runtimeContext.AttachCredentials()
-			if err != nil {
-				return fmt.Errorf("failed to load credentials: %w", err)
+			if isLoadCredentials(cmd) {
+				err := runtimeContext.AttachCredentials()
+				if err != nil {
+					return fmt.Errorf("failed to attach credentials: %w", err)
+				}
 			}
 
-			err = runtimeContext.AttachEnvironmentSet()
+			err := runtimeContext.AttachEnvironmentSet()
 			if err != nil {
 				return fmt.Errorf("failed to load environment details: %w", err)
 			}
@@ -148,6 +150,23 @@ func isLoadEnvAndConfig(cmd *cobra.Command) bool {
 		"fish":              {},
 		"powershell":        {},
 		"zsh":               {},
+		"help":              {},
+	}
+
+	_, exists := excludedCommands[cmd.Name()]
+	return !exists
+}
+
+func isLoadCredentials(cmd *cobra.Command) bool {
+	// It is not expected to have the credentials loaded when running the following commands
+	var excludedCommands = map[string]struct{}{
+		"version":    {},
+		"login":      {},
+		"bash":       {},
+		"fish":       {},
+		"powershell": {},
+		"zsh":        {},
+		"help":       {},
 	}
 
 	_, exists := excludedCommands[cmd.Name()]

--- a/cmd/workflow/deploy/artifacts_test.go
+++ b/cmd/workflow/deploy/artifacts_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/jarcoal/httpmock"
 	"github.com/stretchr/testify/require"
 
+	"github.com/smartcontractkit/cre-cli/internal/credentials"
 	"github.com/smartcontractkit/cre-cli/internal/testutil/chainsim"
 )
 
@@ -61,6 +62,9 @@ type GraphQLRequest struct {
 func TestUpload_SuccessAndErrorCases(t *testing.T) {
 	httpmock.Activate()
 	t.Cleanup(httpmock.DeactivateAndReset)
+
+	// Set dummy API key
+	t.Setenv(credentials.CreApiKeyVar, "test-api")
 
 	simulatedEnvironment := chainsim.NewSimulatedEnvironment(t)
 	ctx, buf := simulatedEnvironment.NewRuntimeContextWithBufferedOutput()
@@ -127,6 +131,9 @@ func TestUploadArtifactToStorageService_OriginError(t *testing.T) {
 	httpmock.Activate()
 	t.Cleanup(httpmock.DeactivateAndReset)
 
+	// Set dummy API key
+	t.Setenv(credentials.CreApiKeyVar, "test-api")
+
 	simulatedEnvironment := chainsim.NewSimulatedEnvironment(t)
 	runtimeContext, buf := simulatedEnvironment.NewRuntimeContextWithBufferedOutput()
 	h := newHandler(runtimeContext, buf)
@@ -155,6 +162,9 @@ func TestUploadArtifactToStorageService_OriginError(t *testing.T) {
 func TestUploadArtifactToStorageService_AlreadyExistsError(t *testing.T) {
 	httpmock.Activate()
 	t.Cleanup(httpmock.DeactivateAndReset)
+
+	// Set dummy API key
+	t.Setenv(credentials.CreApiKeyVar, "test-api")
 
 	simulatedEnvironment := chainsim.NewSimulatedEnvironment(t)
 	runtimeContext, buf := simulatedEnvironment.NewRuntimeContextWithBufferedOutput()

--- a/internal/credentials/credentials.go
+++ b/internal/credentials/credentials.go
@@ -21,6 +21,7 @@ type Credentials struct {
 	Tokens   *CreLoginTokenSet `yaml:"tokens"`
 	APIKey   string            `yaml:"api_key"`
 	AuthType string            `yaml:"auth_type"`
+	log      *zerolog.Logger
 }
 
 const (
@@ -32,10 +33,14 @@ const (
 )
 
 func New(logger *zerolog.Logger) (*Credentials, error) {
-	cfg := &Credentials{AuthType: AuthTypeBearer}
+	cfg := &Credentials{
+		AuthType: AuthTypeBearer,
+		log:      logger,
+	}
 	if key := os.Getenv(CreApiKeyVar); key != "" {
 		cfg.APIKey = key
 		cfg.AuthType = AuthTypeApiKey
+		return cfg, nil
 	}
 
 	home, err := os.UserHomeDir()
@@ -45,12 +50,14 @@ func New(logger *zerolog.Logger) (*Credentials, error) {
 	path := filepath.Join(home, ConfigDir, ConfigFile)
 	data, err := os.ReadFile(path)
 	if err != nil {
-		logger.Debug().Msg("you are not logged in, try running cre login")
-		return cfg, nil
+		return nil, fmt.Errorf("you are not logged in, try running cre login")
 	}
 
 	if err := yaml.Unmarshal(data, &cfg.Tokens); err != nil {
 		return nil, err
+	}
+	if cfg.Tokens == nil || cfg.Tokens.AccessToken == "" {
+		return nil, fmt.Errorf("you are not logged in, try running cre login")
 	}
 	return cfg, nil
 }

--- a/internal/credentials/credentials_test.go
+++ b/internal/credentials/credentials_test.go
@@ -13,18 +13,9 @@ func TestNew_Default(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	logger := testutil.NewTestLogger()
 
-	cfg, err := New(logger)
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
-	}
-	if cfg.APIKey != "" {
-		t.Errorf("expected empty APIKey, got %q", cfg.APIKey)
-	}
-	if cfg.AuthType != AuthTypeBearer {
-		t.Errorf("expected AuthType %q, got %q", AuthTypeBearer, cfg.AuthType)
-	}
-	if cfg.Tokens != nil {
-		t.Error("expected nil Tokens when no config file present")
+	_, err := New(logger)
+	if err == nil || err.Error() != "you are not logged in, try running cre login" {
+		t.Fatalf("expected error %q, got %v", "you are not logged in, try running cre login", err)
 	}
 }
 

--- a/test/account_test.go
+++ b/test/account_test.go
@@ -25,6 +25,7 @@ import (
 	workflow_registry_v2_wrapper "github.com/smartcontractkit/chainlink-evm/gethwrappers/workflow/generated/workflow_registry_wrapper_v2"
 
 	"github.com/smartcontractkit/cre-cli/internal/constants"
+	"github.com/smartcontractkit/cre-cli/internal/credentials"
 	"github.com/smartcontractkit/cre-cli/internal/environments"
 	"github.com/smartcontractkit/cre-cli/internal/settings"
 	test "github.com/smartcontractkit/cre-cli/test/contracts"
@@ -52,6 +53,9 @@ func TestCLIAccountLinkListUnlinkFlow_EOA(t *testing.T) {
 	t.Setenv(environments.EnvVarWorkflowRegistryChainName, TestChainName)
 	t.Setenv(environments.EnvVarCapabilitiesRegistryAddress, "0xCf7Ed3AccA5a467e9e704C703E8D87F634fB0Fc9")
 	t.Setenv(environments.EnvVarCapabilitiesRegistryChainName, TestChainName)
+
+	// Set dummy API key
+	t.Setenv(credentials.CreApiKeyVar, "test-api")
 
 	registryAddr := os.Getenv(environments.EnvVarWorkflowRegistryAddress)
 	require.NotEmpty(t, registryAddr, "registry address env must be set")

--- a/test/init_and_binding_generation_test.go
+++ b/test/init_and_binding_generation_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/cre-cli/internal/constants"
+	"github.com/smartcontractkit/cre-cli/internal/credentials"
 	"github.com/smartcontractkit/cre-cli/internal/settings"
 )
 
@@ -24,6 +25,9 @@ func TestE2EInit_DevPoRTemplate(t *testing.T) {
 
 	ethKey := "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
 	t.Setenv(settings.EthPrivateKeyEnvVar, ethKey)
+
+	// Set dummy API key
+	t.Setenv(credentials.CreApiKeyVar, "test-api")
 
 	initArgs := []string{
 		"init",

--- a/test/secrets_test.go
+++ b/test/secrets_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/smartcontractkit/cre-cli/cmd/secrets/common"
 	"github.com/smartcontractkit/cre-cli/cmd/secrets/delete"
 	"github.com/smartcontractkit/cre-cli/internal/constants"
+	"github.com/smartcontractkit/cre-cli/internal/credentials"
 	"github.com/smartcontractkit/cre-cli/internal/environments"
 )
 
@@ -190,6 +191,9 @@ func TestCLISecretsWithEoa(t *testing.T) {
 	t.Setenv(environments.EnvVarWorkflowRegistryChainName, TestChainName)
 	t.Setenv(environments.EnvVarCapabilitiesRegistryAddress, "0xCf7Ed3AccA5a467e9e704C703E8D87F634fB0Fc9")
 	t.Setenv(environments.EnvVarCapabilitiesRegistryChainName, TestChainName)
+
+	// Set dummy API key
+	t.Setenv(credentials.CreApiKeyVar, "test-api")
 
 	// set up a mock server to simulate the vault gateway
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/test/workflow_happy_path_1_test.go
+++ b/test/workflow_happy_path_1_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/cre-cli/internal/constants"
+	"github.com/smartcontractkit/cre-cli/internal/credentials"
 	"github.com/smartcontractkit/cre-cli/internal/environments"
 	"github.com/smartcontractkit/cre-cli/internal/settings"
 )
@@ -232,6 +233,9 @@ func TestCLIWorkflowDeployWithEoa(t *testing.T) {
 	t.Setenv(environments.EnvVarWorkflowRegistryChainName, TestChainName)
 	t.Setenv(environments.EnvVarCapabilitiesRegistryAddress, "0xCf7Ed3AccA5a467e9e704C703E8D87F634fB0Fc9")
 	t.Setenv(environments.EnvVarCapabilitiesRegistryChainName, TestChainName)
+
+	// Set dummy API key
+	t.Setenv(credentials.CreApiKeyVar, "test-api")
 
 	// Deploy with mocked storage
 	out := tc.workflowDeployEoaWithMockStorage(t)

--- a/test/workflow_happy_path_2_test.go
+++ b/test/workflow_happy_path_2_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/cre-cli/internal/constants"
+	"github.com/smartcontractkit/cre-cli/internal/credentials"
 	"github.com/smartcontractkit/cre-cli/internal/environments"
 	"github.com/smartcontractkit/cre-cli/internal/settings"
 )
@@ -240,6 +241,9 @@ func TestCLIWorkflowDeployWithEoaHappyPath2(t *testing.T) {
 	t.Setenv(environments.EnvVarWorkflowRegistryChainName, TestChainName)
 	t.Setenv(environments.EnvVarCapabilitiesRegistryAddress, "0xCf7Ed3AccA5a467e9e704C703E8D87F634fB0Fc9")
 	t.Setenv(environments.EnvVarCapabilitiesRegistryChainName, TestChainName)
+
+	// Set dummy API key
+	t.Setenv(credentials.CreApiKeyVar, "test-api")
 
 	// Use existing config file from test project
 	_, thisFile, _, _ := runtime.Caller(0)


### PR DESCRIPTION
[DEVSVCS-2626](https://smartcontract-it.atlassian.net/browse/DEVSVCS-2626)

This pull request improves the handling of credentials loading and error reporting in the CLI, strengthens test reliability by setting required environment variables, and refines the logic for determining when credentials are needed. The most significant changes are grouped below:

**Credentials Handling and Error Reporting:**

* The `Credentials` constructor (`New`) now returns an error if the user is not logged in (i.e., no API key is set and no valid tokens are found), instead of silently returning a partially filled struct. This ensures that credential errors are surfaced immediately and clearly. [[1]](diffhunk://#diff-3d8bb7e5e85c3aaa46dc91307ccab11b63766fb3f68ec968b5de6efcba9030bcL35-R43) [[2]](diffhunk://#diff-3d8bb7e5e85c3aaa46dc91307ccab11b63766fb3f68ec968b5de6efcba9030bcL48-R61)
* The CLI startup logic was updated to only attempt to attach credentials for commands that require them, using the new `isLoadCredentials` function to exclude commands like `login`, `version`, and shell completions. Error messages were also improved for clarity. [[1]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fR79-R86) [[2]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fR153-R169)

**Test Improvements:**

* All relevant tests now explicitly set a dummy API key in the environment using `t.Setenv(credentials.CreApiKeyVar, "test-api")` to ensure consistent test behavior regardless of the developer's environment. This change was applied across multiple test files and functions. [[1]](diffhunk://#diff-c0bc7ed06b84a656053e3ea7a8e5799d68f6312ee139d9b6187f95dd22cf2df2R66-R68) [[2]](diffhunk://#diff-c0bc7ed06b84a656053e3ea7a8e5799d68f6312ee139d9b6187f95dd22cf2df2R134-R136) [[3]](diffhunk://#diff-c0bc7ed06b84a656053e3ea7a8e5799d68f6312ee139d9b6187f95dd22cf2df2R166-R168) [[4]](diffhunk://#diff-953595b17309e9dca8da17a6700e8c7899f07795e70ca73e493d2b9d481921fcR57-R59) [[5]](diffhunk://#diff-d3bc62d5c2880d6f7bdf9ad44ecc78688d2e6ca29047554bf662a465f97ad4d9R29-R31) [[6]](diffhunk://#diff-de3143815efad1dcf85935286b81aee8a0f2e28790c735015974f17252d7be31R195-R197) [[7]](diffhunk://#diff-cd75204c176a9e89f1de9d3d30d59ac62b70b9f58512133459a0f28d3c90c53bR237-R239) [[8]](diffhunk://#diff-1ff998f9587547411465ef62d3589e8bd7e12efee36b0510375764e9020a9d62R245-R247)

[DEVSVCS-2626]: https://smartcontract-it.atlassian.net/browse/DEVSVCS-2626?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ