### PR TITLE
Use TS SDK version that works on Windows

### DIFF
--- a/cmd/creinit/template/workflow/typescriptPorExampleDev/package.json.tpl
+++ b/cmd/creinit/template/workflow/typescriptPorExampleDev/package.json.tpl
@@ -8,7 +8,7 @@
   },
   "license": "UNLICENSED",
   "dependencies": {
-    "@chainlink/cre-sdk": "0.0.7-alpha",
+    "@chainlink/cre-sdk": "0.0.8-alpha",
     "viem": "2.34.0",
     "zod": "3.25.76"
   },

--- a/cmd/creinit/template/workflow/typescriptSimpleExample/package.json.tpl
+++ b/cmd/creinit/template/workflow/typescriptSimpleExample/package.json.tpl
@@ -8,7 +8,7 @@
   },
   "license": "UNLICENSED",
   "dependencies": {
-    "@chainlink/cre-sdk": "0.0.7-alpha"
+    "@chainlink/cre-sdk": "0.0.8-alpha"
   },
   "devDependencies": {
     "@types/bun": "1.2.21"


### PR DESCRIPTION
Update TS templates to point to the newest SDK which fixes workflow compilation on Windows.