### PR TITLE
fix: workflow delete edge case

### DIFF
--- a/cmd/workflow/delete/delete.go
+++ b/cmd/workflow/delete/delete.go
@@ -212,7 +212,7 @@ func (h *handler) Execute() error {
 		// Workflow artifacts deletion will be handled by a background cleanup process.
 	}
 	if len(errs) > 0 {
-		return fmt.Errorf("failed to delete some workflows: %v", errors.Join(errs...))
+		return fmt.Errorf("failed to delete some workflows: %w", errors.Join(errs...))
 	}
 	fmt.Println("Workflows deleted successfully.")
 	return nil


### PR DESCRIPTION
If workflow delete fails due to RPC issues, the CLI still outputs `Workflows deleted successfully.`. Fixing this behavior in this PR.