### PR TITLE
proper msg for unauthorized users

### DIFF
--- a/cmd/account/link_key/link_key.go
+++ b/cmd/account/link_key/link_key.go
@@ -251,6 +251,15 @@ mutation InitiateLinking($request: InitiateLinkingRequest!) {
 
 	if err := graphqlclient.New(h.credentials, h.environmentSet, h.log).
 		Execute(ctx, req, &container); err != nil {
+		s := strings.ToLower(err.Error())
+		if strings.Contains(s, "unauthorized") {
+			unauthorizedMsg := `✖ Deployment blocked: your organization is not authorized to deploy workflows.
+During private Beta, only approved organizations can deploy workflows to CRE environment.
+
+→ If you believe this is an error or would like to request access, please visit:
+https://docs.cre.link/request-deployment-access`
+			return initiateLinkingResponse{}, fmt.Errorf("\n%s\n%w", unauthorizedMsg, err)
+		}
 		return initiateLinkingResponse{}, fmt.Errorf("graphql request failed: %w", err)
 	}
 


### PR DESCRIPTION
Gating is controlled in the link-key level. only authorized org can link key, and without linking, users cant deploy/pause etc.

**link:**
```
leishi@MB-MJ2FP47WKD test108 % cre account link-key           
Linking web3 key to your CRE organization
Target :                 staging
✔ Using Address :        0x592AC489DFa04E0BeB185aC2DE8bb46E2F9821fe

Provide a label for your owner address: adfas
Provide a label for your owner address: adfas

Checking existing registrations...
✓ No existing link found for this address
Starting linking: owner=0x592AC489DFa04E0BeB185aC2DE8bb46E2F9821fe, label=adfas
Error: 
✖ Deployment blocked: your organization is not authorized to deploy workflows.
During private Beta, only approved organizations can deploy workflows to CRE environment.

→ If you believe this is an error or would like to request access, please visit:
https://docs.cre.link/request-deployment-access
graphql: unauthorized: org is restricted
Usage:
  cre account link-key [flags]

Flags:
  -h, --help                 help for link-key
  -l, --owner-label string   Label for the workflow owner
      --unsigned             If set, the command will either return the raw transaction instead of sending it to the network or execute the second step of secrets operations using a previously generated raw transaction
      --yes                  If set, the command will skip the confirmation prompt and proceed with the operation even if it is potentially destructive

Global Flags:
  -e, --env string            Path to .env file which contains sensitive info (default ".env")
  -R, --project-root string   Path to the project root
  -T, --target string         Set the target settings
  -v, --verbose               Print DEBUG logs


```

**deploy:**
```
leishi@MB-MJ2FP47WKD test108 % cre workflow deploy ./flow108

Deploying Workflow :     flow108
Target :                 staging
Owner Address :          0x592AC489DFa04E0BeB185aC2DE8bb46E2F9821fe

Compiling workflow...
Workflow compiled successfully

Verifying ownership...
Workflow owner link status: owner=0x592AC489DFa04E0BeB185aC2DE8bb46E2F9821fe, linked=false
Owner not linked. Attempting auto-link: owner=0x592AC489DFa04E0BeB185aC2DE8bb46E2F9821fe
Linking web3 key to your CRE organization
Target :                 staging
✔ Using Address :        0x592AC489DFa04E0BeB185aC2DE8bb46E2F9821fe

Provide a label for your owner address: lei label

Checking existing registrations...
✓ No existing link found for this address
Starting linking: owner=0x592AC489DFa04E0BeB185aC2DE8bb46E2F9821fe, label=lei label
Error: auto-link attempt failed: 
✖ Deployment blocked: your organization is not authorized to deploy workflows.
During private Beta, only approved organizations can deploy workflows to CRE environment.

→ If you believe this is an error or would like to request access, please visit:
https://docs.cre.link/request-deployment-access
graphql: unauthorized: org is restricted
Usage:
  cre workflow deploy <workflow-folder-path> [flags]

Examples:

                cre workflow deploy ./my-workflow
                

Flags:
  -r, --auto-start           Activate and run the workflow after registration, or pause it (default true)
  -h, --help                 help for deploy
  -o, --output string        The output file for the compiled WASM binary encoded in base64 (default "./binary.wasm.br.b64")
  -l, --owner-label string   Label for the workflow owner (used during auto-link if owner is not already linked)
      --unsigned             If set, the command will either return the raw transaction instead of sending it to the network or execute the second step of secrets operations using a previously generated raw transaction
      --yes                  If set, the command will skip the confirmation prompt and proceed with the operation even if it is potentially destructive

Global Flags:
  -e, --env string            Path to .env file which contains sensitive info (default ".env")
  -R, --project-root string   Path to the project root
  -T, --target string         Set the target settings
  -v, --verbose               Print DEBUG logs

```