### PR TITLE
remove the default in setting, use documentation for msig users

### DIFF
--- a/internal/settings/settings_generate.go
+++ b/internal/settings/settings_generate.go
@@ -47,9 +47,8 @@ func GetDefaultReplacements() map[string]string {
 		"ProductionTestnetDonFamily": constants.DefaultProductionTestnetDonFamily,
 		"ProductionDonFamily":        constants.DefaultProductionDonFamily,
 
-		"WorkflowOwnerAddress": "(optional) Multi-signature contract address",
-		"ConfigPath":           "./config.json",
-		"SecretsPath":          "",
+		"ConfigPath":  "./config.json",
+		"SecretsPath": "../secrets.yaml",
 	}
 }
 

--- a/internal/settings/template/project.yaml.tpl
+++ b/internal/settings/template/project.yaml.tpl
@@ -30,8 +30,6 @@ staging-settings:
 production-settings:
   cre-cli:
     don-family: "{{StagingDonFamily}}"
-  account:
-    workflow-owner-address: "{{WorkflowOwnerAddress}}"
   rpcs:
     - chain-name: {{EthSepoliaChainName}}
       url: {{EthSepoliaRpcUrl}}


### PR DESCRIPTION
Per DCW, owner is not needed for EOA users. will use documentation to instruct pro users (using MSIG) to add owner in setting.