### PR TITLE
feat: add preview-build pipeline

### DIFF
--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -4,12 +4,11 @@ permissions:
 
 on:
   pull_request:
-    types:
-      - labeled
+    types: [ready_for_review, synchronize, reopened, labeled]
 
 jobs:
   build-linux:
-    if: github.event.label.name == 'preview'
+    if: github.event.pull_request.state == 'open' && contains(github.event.pull_request.labels.*.name, 'preview')
     name: Build Linux Binaries
     runs-on: ubuntu-latest
     strategy:
@@ -58,7 +57,7 @@ jobs:
             cre_preview-${{ github.sha }}_linux_${{ matrix.arch }}.tar.gz
 
   build-darwin:
-    if: github.event.label.name == 'preview'
+    if: github.event.pull_request.state == 'open' && contains(github.event.pull_request.labels.*.name, 'preview')
     name: Build Darwin Binaries
     runs-on: macos-latest
     strategy:
@@ -93,7 +92,7 @@ jobs:
             cre_${{ env.VERSION }}_darwin_${{ matrix.arch }}.zip
 
   build-windows:
-    if: github.event.label.name == 'preview'
+    if: github.event.pull_request.state == 'open' && contains(github.event.pull_request.labels.*.name, 'preview')
     name: Build Windows Binaries
     runs-on: windows-latest
     env:
@@ -143,7 +142,7 @@ jobs:
             cre_${{ env.VERSION }}_windows_${{ matrix.arch }}.zip
 
   post-preview-comment:
-    if: github.event.label.name == 'preview'
+    if: github.event.pull_request.state == 'open' && contains(github.event.pull_request.labels.*.name, 'preview')
     name: Post Preview Comment
     needs: [build-linux, build-darwin, build-windows]
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request adds a new GitHub Actions workflow to automate building preview binaries for Linux, macOS (Darwin), and Windows whenever a pull request is labeled with "preview" and is open. The workflow builds platform-specific binaries, archives them, uploads the artifacts, and posts a comment on the pull request with download instructions.

**New CI workflow for preview builds:**

* Adds `.github/workflows/preview-build.yml` to build and archive Go binaries for Linux (`amd64`, `arm64`), macOS (`amd64`, `arm64`), and Windows (`amd64`) when a PR is labeled "preview".
* Installs platform-specific dependencies and cross-compilers for each OS and architecture to ensure successful builds.
* Uploads the resulting binaries as artifacts for each platform, making them available for download directly from the GitHub Actions run.

**Automated PR feedback:**

* Posts a comment on the pull request with a link to the build artifacts, so reviewers and contributors can easily access and test the preview builds.