### PR TITLE
fix compile error

### DIFF
--- a/cmd/creinit/template/workflow/porExampleDev/contracts/evm/src/generated/balance_reader/BalanceReader.go
+++ b/cmd/creinit/template/workflow/porExampleDev/contracts/evm/src/generated/balance_reader/BalanceReader.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"reflect"
 	"strings"
 
 	ethereum "github.com/ethereum/go-ethereum"
@@ -46,6 +47,7 @@ var (
 	_ = cre.ResponseBufferTooSmall
 	_ = rpc.API{}
 	_ = json.Unmarshal
+	_ = reflect.Bool
 )
 
 var BalanceReaderMetaData = &bind.MetaData{
@@ -64,7 +66,8 @@ type GetNativeBalancesInput struct {
 // Errors
 
 // Events
-// The <Event> struct should be used as a filter (for log triggers).
+// The <Event>Topics struct should be used as a filter (for log triggers).
+// Note: It is only possible to filter on indexed fields.
 // Indexed (string and bytes) fields will be of type common.Hash.
 // They need to he (crypto.Keccak256) hashed and passed in.
 // Indexed (tuple/slice/array) fields can be passed in as is, the Encode<Event>Topics function will handle the hashing.

--- a/cmd/creinit/template/workflow/porExampleDev/workflow.go.tpl
+++ b/cmd/creinit/template/workflow/porExampleDev/workflow.go.tpl
@@ -94,7 +94,7 @@ func InitWorkflow(config *Config, logger *slog.Logger, secretsProvider cre.Secre
 		if err != nil {
 			return nil, fmt.Errorf("failed to get chain selector: %w", err)
 		}
-		trigger, err := msgEmitter.LogTriggerMessageEmittedLog(chainSelector, evm.ConfidenceLevel_CONFIDENCE_LEVEL_LATEST, []message_emitter.MessageEmitted{})
+		trigger, err := msgEmitter.LogTriggerMessageEmittedLog(chainSelector, evm.ConfidenceLevel_CONFIDENCE_LEVEL_LATEST, []message_emitter.MessageEmittedTopics{})
 		if err != nil {
 			return nil, fmt.Errorf("failed to create message emitted trigger: %w", err)
 		}


### PR DESCRIPTION
bug introduced in https://github.com/smartcontractkit/cre-cli/pull/124/files#r2469754912

tested cron, worked fine. Log trigger is giving an error, I believe it is RPC related, so not related to this fix.

```
leishi@MB-MJ2FP47WKD test117 % cre workflow simulate flow117
Workflow compiled

🚀 Workflow simulation ready. Please select a trigger:
1. cron-trigger@1.0.0 Trigger
2. evm:ChainSelector:16015286601757825753@1.0.0 LogTrigger

Enter your choice (1-2): 1

2025-10-28T07:39:33Z [SIMULATION] Simulator Initialized

2025-10-28T07:39:33Z [SIMULATION] Running trigger trigger=cron-trigger@1.0.0
2025-10-28T07:39:33Z [USER LOG] msg="fetching por" url=https://api.real-time-reserves.verinumus.io/v1/chainlink/proof-of-reserves/TrueUSD evms="[{TokenAddress:0x4700A50d858Cb281847ca4Ee0938F80DEfB3F1dd ReserveManagerAddress:0x51933aD3A79c770cb6800585325649494120401a BalanceReaderAddress:0x4b0739c94C1389B55481cb7506c62430cA7211Cf MessageEmitterAddress:0x1d598672486ecB50685Da5497390571Ac4E93FDc ChainName:ethereum-testnet-sepolia GasLimit:1000000}]"
2025-10-28T07:39:34Z [USER LOG] msg=ReserveInfo reserveInfo="&{LastUpdated:2025-10-28 14:39:06.174 +0000 UTC TotalReserve:494515082.75}"
2025-10-28T07:39:34Z [USER LOG] msg=TotalSupply totalSupply=1000000000000000000000000
2025-10-28T07:39:34Z [USER LOG] msg=TotalReserveScaled totalReserveScaled=494515082750000000000000000
2025-10-28T07:39:34Z [USER LOG] msg="Getting native balances" address=0x4b0739c94C1389B55481cb7506c62430cA7211Cf tokenAddress=0x4700A50d858Cb281847ca4Ee0938F80DEfB3F1dd
2025-10-28T07:39:34Z [USER LOG] msg="Native token balance" token=0x4700A50d858Cb281847ca4Ee0938F80DEfB3F1dd balance=0
2025-10-28T07:39:34Z [USER LOG] msg="Updating reserves" totalSupply=1000000000000000000000000 totalReserveScaled=494515082750000000000000000
2025-10-28T07:39:34Z [USER LOG] msg="Writing report" totalSupply=1000000000000000000000000 totalReserveScaled=494515082750000000000000000
2025-10-28T07:39:34Z [USER LOG] msg="Write report succeeded" response="tx_status:TX_STATUS_SUCCESS receiver_contract_execution_status:RECEIVER_CONTRACT_EXECUTION_STATUS_SUCCESS transaction_fee:{}"
2025-10-28T07:39:34Z [USER LOG] msg="Write report transaction succeeded at" txHash=0x0000000000000000000000000000000000000000000000000000000000000000

Workflow Simulation Result:
 "494515082.75"

2025-10-28T07:39:34Z [SIMULATION] Execution finished signal received
2025-10-28T07:39:34Z [SIMULATION] Skipping WorkflowEngineV2
leishi@MB-MJ2FP47WKD test117 % cre workflow simulate flow117
Workflow compiled

🚀 Workflow simulation ready. Please select a trigger:
1. cron-trigger@1.0.0 Trigger
2. evm:ChainSelector:16015286601757825753@1.0.0 LogTrigger

Enter your choice (1-2): 2


🔗 EVM Trigger Configuration:
Please provide the transaction hash and event index for the EVM log event.
Enter transaction hash (0x...): 0x420721d7d00130a03c5b525b2dbfd42550906ddb3075e8377f9bb5d1a5992f8e
Enter event index (0-based): 0
Fetching transaction receipt for transaction 0x420721d7d00130a03c5b525b2dbfd42550906ddb3075e8377f9bb5d1a5992f8e...
Found log event at index 0: contract=0x1d598672486ecB50685Da5497390571Ac4E93FDc, topics=3
Created EVM trigger log for transaction 0x420721d7d00130a03c5b525b2dbfd42550906ddb3075e8377f9bb5d1a5992f8e, event 0
2025-10-28T07:41:32Z [SIMULATION] Simulator Initialized

2025-10-28T07:41:32Z [SIMULATION] Running trigger trigger=evm:ChainSelector:16015286601757825753@1.0.0
2025-10-28T07:41:32Z [USER LOG] msg="Message retrieved from the event log" message="this is a test message"
2025-10-28T07:41:32Z [USER LOG] msg="Block number of event log" blockNumber=8713511
2025-10-28T07:41:32Z [USER LOG] msg="Could not read from contract" contract_chain=ethereum-testnet-sepolia err="failed to execute capability: historical state 95a9026256fc238bb206622257ce80205bd9a30432399ef6ef7154f22af127b1 is not available"
Workflow execution failed:
 failed to execute capability: historical state 95a9026256fc238bb206622257ce80205bd9a30432399ef6ef7154f22af127b1 is not available

```
