### PR TITLE
Point TS SDK to v1.0.0

### DIFF
--- a/cmd/creinit/template/workflow/typescriptPorExampleDev/package.json.tpl
+++ b/cmd/creinit/template/workflow/typescriptPorExampleDev/package.json.tpl
@@ -8,7 +8,7 @@
   },
   "license": "UNLICENSED",
   "dependencies": {
-    "@chainlink/cre-sdk": "1.0.0-beta.1",
+    "@chainlink/cre-sdk": "1.0.0",
     "viem": "2.34.0",
     "zod": "3.25.76"
   },

--- a/cmd/creinit/template/workflow/typescriptSimpleExample/package.json.tpl
+++ b/cmd/creinit/template/workflow/typescriptSimpleExample/package.json.tpl
@@ -8,7 +8,7 @@
   },
   "license": "UNLICENSED",
   "dependencies": {
-    "@chainlink/cre-sdk": "1.0.0-beta.1"
+    "@chainlink/cre-sdk": "1.0.0"
   },
   "devDependencies": {
     "@types/bun": "1.2.21"


### PR DESCRIPTION
Following latest request `cre-sdk` has been re-released with `1.0.0` version (no code changes compared to `1.0.0-beta.1`).

Tested: I did a local build, created two workflows with `cre init` and both worked during simulation.