### PR TITLE
Allow patches and minor

### DIFF
--- a/cmd/creinit/template/workflow/typescriptPorExampleDev/package.json.tpl
+++ b/cmd/creinit/template/workflow/typescriptPorExampleDev/package.json.tpl
@@ -8,7 +8,7 @@
   },
   "license": "UNLICENSED",
   "dependencies": {
-    "@chainlink/cre-sdk": "1.0.0",
+    "@chainlink/cre-sdk": "^1.0.0",
     "viem": "2.34.0",
     "zod": "3.25.76"
   },

--- a/cmd/creinit/template/workflow/typescriptSimpleExample/package.json.tpl
+++ b/cmd/creinit/template/workflow/typescriptSimpleExample/package.json.tpl
@@ -8,7 +8,7 @@
   },
   "license": "UNLICENSED",
   "dependencies": {
-    "@chainlink/cre-sdk": "1.0.0"
+    "@chainlink/cre-sdk": "^1.0.0"
   },
   "devDependencies": {
     "@types/bun": "1.2.21"


### PR DESCRIPTION
The caret (^) tells bun to install the latest compatible minor or patch version under the same major version of a dependency. I believe in 1.0.0 this should be the way to go.

We wouldn't need to create release of cre cli every time we have a non-breaking patch to ts sdk.