### PR TITLE
add build output to compile error

### DIFF
--- a/cmd/workflow/deploy/compile.go
+++ b/cmd/workflow/deploy/compile.go
@@ -75,7 +75,9 @@ func (h *handler) Compile() error {
 	buildOutput, err := buildCmd.CombinedOutput()
 	if err != nil {
 		fmt.Println(string(buildOutput))
-		return fmt.Errorf("failed to compile workflow: %w", err)
+
+		out := strings.TrimSpace(string(buildOutput))
+		return fmt.Errorf("failed to compile workflow: %w\nbuild output:\n%s", err, out)
 	}
 	h.log.Debug().Msgf("Build output: %s", buildOutput)
 	fmt.Println("Workflow compiled successfully")

--- a/cmd/workflow/simulate/simulate.go
+++ b/cmd/workflow/simulate/simulate.go
@@ -227,8 +227,9 @@ func (h *handler) Execute(inputs Inputs) error {
 	// Execute the build command
 	buildOutput, err := buildCmd.CombinedOutput()
 	if err != nil {
-		h.log.Info().Msg(string(buildOutput))
-		return fmt.Errorf("failed to compile workflow: %w", err)
+		out := strings.TrimSpace(string(buildOutput))
+		h.log.Info().Msg(out)
+		return fmt.Errorf("failed to compile workflow: %w\nbuild output:\n%s", err, out)
 	}
 	h.log.Debug().Msgf("Build output: %s", buildOutput)
 	fmt.Println("Workflow compiled")


### PR DESCRIPTION
```
Error: failed to compile workflow: exit status 1
build output:
# testgo1/my-workflow
./workflow.go:312:14: undefined: PORResponse3

```