### PR TITLE
feat: update auth validation to support API keys

### DIFF
--- a/cmd/whoami/whoami_test.go
+++ b/cmd/whoami/whoami_test.go
@@ -34,9 +34,8 @@ func TestHandlerExecute(t *testing.T) {
 					resp := map[string]interface{}{
 						"data": map[string]interface{}{
 							"getAccountDetails": map[string]string{
-								"username":       "alice",
-								"organizationID": "org-42",
-								"emailAddress":   "alice@example.com",
+								"username":     "alice",
+								"emailAddress": "alice@example.com",
 							},
 							"getOrganization": map[string]string{
 								"organizationID": "org-42",
@@ -56,6 +55,35 @@ func TestHandlerExecute(t *testing.T) {
 			wantErr: false,
 			wantLogSnips: []string{
 				"Account details retrieved:", "Email:             alice@example.com",
+				"Organization ID:   org-42",
+				"Organization Name: Alice's Org",
+			},
+		},
+		{
+			name: "successful response - no account details (API key)",
+			graphqlHandler: func(w http.ResponseWriter, r *http.Request) {
+				body, _ := io.ReadAll(r.Body)
+				if strings.Contains(string(body), "getAccountDetails") && strings.Contains(string(body), "getOrganization") {
+					resp := map[string]interface{}{
+						"data": map[string]interface{}{
+							"getOrganization": map[string]string{
+								"organizationID": "org-42",
+								"displayName":    "Alice's Org",
+							},
+						},
+					}
+					w.Header().Set("Content-Type", "application/json")
+					if err := json.NewEncoder(w).Encode(resp); err != nil {
+						t.Fatalf("failed to encode GraphQL response: %v", err)
+					}
+				} else {
+					http.Error(w, "bad request", http.StatusBadRequest)
+					return
+				}
+			},
+			wantErr: false,
+			wantLogSnips: []string{
+				"Account details retrieved:",
 				"Organization ID:   org-42",
 				"Organization Name: Alice's Org",
 			},

--- a/internal/authvalidation/validator.go
+++ b/internal/authvalidation/validator.go
@@ -12,10 +12,9 @@ import (
 	"github.com/smartcontractkit/cre-cli/internal/environments"
 )
 
-const queryGetAccountDetails = `
-query GetAccountDetails {
-	getAccountDetails {
-		userId
+const queryOrganization = `
+query GetOrganizationDetails  {
+	getOrganization {
 		organizationId
 	}
 }`
@@ -47,13 +46,12 @@ func (v *Validator) ValidateCredentials(validationCtx context.Context, creds *cr
 		return nil
 	}
 
-	req := graphql.NewRequest(queryGetAccountDetails)
+	req := graphql.NewRequest(queryOrganization)
 
 	var respEnvelope struct {
-		GetAccountDetails struct {
-			UserID         string `json:"userId"`
+		GetOrganization struct {
 			OrganizationID string `json:"organizationId"`
-		} `json:"getAccountDetails"`
+		} `json:"getOrganization"`
 	}
 
 	if err := v.gqlClient.Execute(validationCtx, req, &respEnvelope); err != nil {

--- a/test/init_and_binding_generation_test.go
+++ b/test/init_and_binding_generation_test.go
@@ -46,11 +46,10 @@ func TestE2EInit_DevPoRTemplate(t *testing.T) {
 			w.Header().Set("Content-Type", "application/json")
 
 			// Handle authentication validation query
-			if strings.Contains(req.Query, "getAccountDetails") {
+			if strings.Contains(req.Query, "getOrganization") {
 				_ = json.NewEncoder(w).Encode(map[string]any{
 					"data": map[string]any{
-						"getAccountDetails": map[string]any{
-							"userId":         "test-user-id",
+						"getOrganization": map[string]any{
 							"organizationId": "test-org-id",
 						},
 					},

--- a/test/multi_command_flows/account_happy_path.go
+++ b/test/multi_command_flows/account_happy_path.go
@@ -57,11 +57,10 @@ func RunAccountHappyPath(t *testing.T, tc TestConfig, testEthURL, chainName stri
 		w.Header().Set("Content-Type", "application/json")
 
 		// Handle authentication validation query
-		if strings.Contains(req.Query, "getAccountDetails") {
+		if strings.Contains(req.Query, "getOrganization") {
 			_ = json.NewEncoder(w).Encode(map[string]any{
 				"data": map[string]any{
-					"getAccountDetails": map[string]any{
-						"userId":         "test-user-id",
+					"getOrganization": map[string]any{
 						"organizationId": "test-org-id",
 					},
 				},

--- a/test/multi_command_flows/secrets_happy_path.go
+++ b/test/multi_command_flows/secrets_happy_path.go
@@ -61,11 +61,10 @@ func RunSecretsHappyPath(t *testing.T, tc TestConfig, chainName string) {
 			w.Header().Set("Content-Type", "application/json")
 
 			// Handle authentication validation query
-			if strings.Contains(req.Query, "getAccountDetails") {
+			if strings.Contains(req.Query, "getOrganization") {
 				_ = json.NewEncoder(w).Encode(map[string]any{
 					"data": map[string]any{
-						"getAccountDetails": map[string]any{
-							"userId":         "test-user-id",
+						"getOrganization": map[string]any{
 							"organizationId": "test-org-id",
 						},
 					},
@@ -256,11 +255,10 @@ func RunSecretsListMsig(t *testing.T, tc TestConfig, chainName string) {
 			w.Header().Set("Content-Type", "application/json")
 
 			// Handle authentication validation query
-			if strings.Contains(req.Query, "getAccountDetails") {
+			if strings.Contains(req.Query, "getOrganization") {
 				_ = json.NewEncoder(w).Encode(map[string]any{
 					"data": map[string]any{
-						"getAccountDetails": map[string]any{
-							"userId":         "test-user-id",
+						"getOrganization": map[string]any{
 							"organizationId": "test-org-id",
 						},
 					},

--- a/test/multi_command_flows/workflow_happy_path_1.go
+++ b/test/multi_command_flows/workflow_happy_path_1.go
@@ -61,11 +61,10 @@ func workflowDeployEoaWithMockStorage(t *testing.T, tc TestConfig) (output strin
 			w.Header().Set("Content-Type", "application/json")
 
 			// Handle authentication validation query
-			if strings.Contains(req.Query, "getAccountDetails") {
+			if strings.Contains(req.Query, "getOrganization") {
 				_ = json.NewEncoder(w).Encode(map[string]any{
 					"data": map[string]any{
-						"getAccountDetails": map[string]any{
-							"userId":         "test-user-id",
+						"getOrganization": map[string]any{
 							"organizationId": "test-org-id",
 						},
 					},

--- a/test/multi_command_flows/workflow_happy_path_2.go
+++ b/test/multi_command_flows/workflow_happy_path_2.go
@@ -34,11 +34,10 @@ func workflowDeployEoa(t *testing.T, tc TestConfig) string {
 			w.Header().Set("Content-Type", "application/json")
 
 			// Handle authentication validation query
-			if strings.Contains(req.Query, "getAccountDetails") {
+			if strings.Contains(req.Query, "getOrganization") {
 				_ = json.NewEncoder(w).Encode(map[string]any{
 					"data": map[string]any{
-						"getAccountDetails": map[string]any{
-							"userId":         "test-user-id",
+						"getOrganization": map[string]any{
 							"organizationId": "test-org-id",
 						},
 					},
@@ -155,11 +154,10 @@ func workflowDeployUpdateWithConfig(t *testing.T, tc TestConfig) string {
 			w.Header().Set("Content-Type", "application/json")
 
 			// Handle authentication validation query
-			if strings.Contains(req.Query, "getAccountDetails") {
+			if strings.Contains(req.Query, "getOrganization") {
 				_ = json.NewEncoder(w).Encode(map[string]any{
 					"data": map[string]any{
-						"getAccountDetails": map[string]any{
-							"userId":         "test-user-id",
+						"getOrganization": map[string]any{
 							"organizationId": "test-org-id",
 						},
 					},

--- a/test/multi_command_flows/workflow_happy_path_3.go
+++ b/test/multi_command_flows/workflow_happy_path_3.go
@@ -31,11 +31,10 @@ func workflowInit(t *testing.T, projectRootFlag, projectName, workflowName strin
 			w.Header().Set("Content-Type", "application/json")
 
 			// Handle authentication validation query
-			if strings.Contains(req.Query, "getAccountDetails") {
+			if strings.Contains(req.Query, "getOrganization") {
 				_ = json.NewEncoder(w).Encode(map[string]any{
 					"data": map[string]any{
-						"getAccountDetails": map[string]any{
-							"userId":         "test-user-id",
+						"getOrganization": map[string]any{
 							"organizationId": "test-org-id",
 						},
 					},
@@ -100,11 +99,10 @@ func workflowDeployUnsigned(t *testing.T, tc TestConfig, projectRootFlag, workfl
 			w.Header().Set("Content-Type", "application/json")
 
 			// Handle authentication validation query
-			if strings.Contains(req.Query, "getAccountDetails") {
+			if strings.Contains(req.Query, "getOrganization") {
 				_ = json.NewEncoder(w).Encode(map[string]any{
 					"data": map[string]any{
-						"getAccountDetails": map[string]any{
-							"userId":         "test-user-id",
+						"getOrganization": map[string]any{
 							"organizationId": "test-org-id",
 						},
 					},
@@ -219,11 +217,10 @@ func workflowDeployWithConfigAndLinkedKey(t *testing.T, tc TestConfig, projectRo
 			w.Header().Set("Content-Type", "application/json")
 
 			// Handle authentication validation query
-			if strings.Contains(req.Query, "getAccountDetails") {
+			if strings.Contains(req.Query, "getOrganization") {
 				_ = json.NewEncoder(w).Encode(map[string]any{
 					"data": map[string]any{
-						"getAccountDetails": map[string]any{
-							"userId":         "test-user-id",
+						"getOrganization": map[string]any{
 							"organizationId": "test-org-id",
 						},
 					},

--- a/test/multi_command_flows/workflow_simulator_path.go
+++ b/test/multi_command_flows/workflow_simulator_path.go
@@ -89,11 +89,10 @@ func RunSimulationHappyPath(t *testing.T, tc TestConfig, projectDir string) {
 				w.Header().Set("Content-Type", "application/json")
 
 				// Handle authentication validation query
-				if strings.Contains(req.Query, "getAccountDetails") {
+				if strings.Contains(req.Query, "getOrganization") {
 					_ = json.NewEncoder(w).Encode(map[string]any{
 						"data": map[string]any{
-							"getAccountDetails": map[string]any{
-								"userId":         "test-user-id",
+							"getOrganization": map[string]any{
 								"organizationId": "test-org-id",
 							},
 						},


### PR DESCRIPTION
[DEVSVCS-3145](https://smartcontract-it.atlassian.net/browse/DEVSVCS-3145)

This pull request refactors how organization and account details are queried and handled throughout the CLI and its tests. The main change is the switch from using the `getAccountDetails` GraphQL query to using the `getOrganization` query for authentication validation and organization information retrieval. This simplifies the queries and response handling, especially for API key-based authentication, and ensures consistency across the CLI and test suite.

**Core logic and query updates:**

* Replaced the `getAccountDetails` GraphQL query with the `getOrganization` query in the authentication validation logic in `internal/authvalidation/validator.go`, updating the request and response handling accordingly. [[1]](diffhunk://#diff-4e633621cf53f0e9c6bc6b702ef7d80c83a5d9258b663d42ff76af46cf062462L15-R17) [[2]](diffhunk://#diff-4e633621cf53f0e9c6bc6b702ef7d80c83a5d9258b663d42ff76af46cf062462L50-R54)
* Updated the `whoami` command logic in `cmd/whoami/whoami.go` to use dynamic queries based on authentication method (API key vs. other), and adjusted the response handling to support cases where account details may be missing. [[1]](diffhunk://#diff-c43c6d7741df44792d2add826355ca859bb67c029ec937fa557f937c37437a8dL17-L27) [[2]](diffhunk://#diff-c43c6d7741df44792d2add826355ca859bb67c029ec937fa557f937c37437a8dR46-R77) [[3]](diffhunk://#diff-c43c6d7741df44792d2add826355ca859bb67c029ec937fa557f937c37437a8dR88-R91)

**Test suite consistency:**

* Refactored all test handlers in the test suite (`test/init_and_binding_generation_test.go`, `test/multi_command_flows/*`) to expect and respond to `getOrganization` queries instead of `getAccountDetails`, ensuring tests match the new authentication validation logic. [[1]](diffhunk://#diff-d3bc62d5c2880d6f7bdf9ad44ecc78688d2e6ca29047554bf662a465f97ad4d9L49-R52) [[2]](diffhunk://#diff-1c027f3dbf1bac096266e03d87f698ea3e4ae8f2ec487f783208c6e2746a9d9dL60-R63) [[3]](diffhunk://#diff-6970be50964992ce4d14ea0d90c491f57d09c6842d3a1f96a35f1711e4cf7f04L64-R67) [[4]](diffhunk://#diff-6970be50964992ce4d14ea0d90c491f57d09c6842d3a1f96a35f1711e4cf7f04L259-R261) [[5]](diffhunk://#diff-4e72914b4c33a23e119a634e426bf6f43da452563b47d2cce0f9131527df9335L64-R67) [[6]](diffhunk://#diff-ce0e7fae956640e949b7a000a9ab45e22880f0abd0343d804da2bb61dc339cb1L37-R40) [[7]](diffhunk://#diff-ce0e7fae956640e949b7a000a9ab45e22880f0abd0343d804da2bb61dc339cb1L158-R160) [[8]](diffhunk://#diff-18bdfe6f25e891fe2243624fbe0a82e28cfa0b61cd8ff7b3b2a47c93443b70cfL34-R37) [[9]](diffhunk://#diff-18bdfe6f25e891fe2243624fbe0a82e28cfa0b61cd8ff7b3b2a47c93443b70cfL103-R105) [[10]](diffhunk://#diff-18bdfe6f25e891fe2243624fbe0a82e28cfa0b61cd8ff7b3b2a47c93443b70cfL222-R223) [[11]](diffhunk://#diff-3f7eccc17a2c5f20e00ca97b514764e9d415fa745be37c4198b917a797018395L92-R95)

**Testing enhancements:**

* Added a new test case in `cmd/whoami/whoami_test.go` to verify correct behavior when only organization details are available (API key scenario).

[DEVSVCS-3145]: https://smartcontract-it.atlassian.net/browse/DEVSVCS-3145?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ