### PR TITLE
align the workflow name 10 bytes logic btw simulator and don

### DIFF
--- a/cmd/workflow/simulate/simulate.go
+++ b/cmd/workflow/simulate/simulate.go
@@ -30,7 +30,6 @@ import (
 	httptypedapi "github.com/smartcontractkit/chainlink-common/pkg/capabilities/v2/triggers/http"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
-	pkgworkflows "github.com/smartcontractkit/chainlink-common/pkg/workflows"
 	pb "github.com/smartcontractkit/chainlink-protos/cre/go/sdk"
 	"github.com/smartcontractkit/chainlink-protos/cre/go/values"
 	valuespb "github.com/smartcontractkit/chainlink-protos/cre/go/values/pb"
@@ -437,8 +436,6 @@ func run(
 	}
 	emptyHook := func(context.Context, simulator.RunnerConfig, *capabilities.Registry, []services.Service) {}
 
-	encodedWorkflowName := pkgworkflows.HashTruncateName(inputs.WorkflowName)
-
 	simulator.NewRunner(&simulator.RunnerHooks{
 		Initialize:  simulatorInitialize,
 		BeforeStart: triggerInfoAndBeforeStart.BeforeStart,
@@ -446,7 +443,7 @@ func run(
 		AfterRun:    emptyHook,
 		Cleanup:     simulatorCleanup,
 		Finally:     emptyHook,
-	}).Run(ctx, encodedWorkflowName, binary, config, secrets, simulator.RunnerConfig{
+	}).Run(ctx, inputs.WorkflowName, binary, config, secrets, simulator.RunnerConfig{
 		EnableBeholder: true,
 		EnableBilling:  false,
 		Lggr:           engineLog,


### PR DESCRIPTION


the standalone engine has the check on the workflow name length, https://github.com/smartcontractkit/chainlink/blob/develop/core/services/workflows/cmd/cre/utils/standalone_engine.go#L85

we had the hashing and truncating in simulator to ensure users can give any length of workflow name, but this makes the 10bytes workflow name doesnt align.  Will investigate why we need the length check in workflow_meta.go

----------
update:
confirmed workflow name length is not a problem in simulator, the standalone engine checks only if the name is empty or too long (256 chars). 