### PR TITLE
fix: install script use bash

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 #
 # This is a universal installer script for 'cre'.
 # It detects the OS and architecture, then downloads the correct binary.


### PR DESCRIPTION
This pull request updates the `install/install.sh` script to improve compatibility and user experience, particularly when adding configuration to shell rc files. The most important changes are:

**Shell compatibility and usage:**

* Changed the script's shebang from `#!/bin/sh` to `#!/bin/env bash` to ensure Bash-specific syntax is supported, and updated usage instructions to recommend running the script with `bash` instead of `sh`.

**Shell configuration file updates:**

* Updated the logic for modifying shell rc files (`.bashrc`, `.zshrc`, and `config.fish`) so that configuration is only appended if it hasn't already been added, preventing duplicate entries. [[1]](diffhunk://#diff-65845b92f5ee07169285791a57b33dd35b5792a60a4d436d2c761324a492a2c1R236-R244) [[2]](diffhunk://#diff-65845b92f5ee07169285791a57b33dd35b5792a60a4d436d2c761324a492a2c1R190-R198)
* Used `echo -e` instead of `echo` to correctly interpret escape sequences (like `\n`) when adding comments and commands to shell rc files. [[1]](diffhunk://#diff-65845b92f5ee07169285791a57b33dd35b5792a60a4d436d2c761324a492a2c1R236-R244) [[2]](diffhunk://#diff-65845b92f5ee07169285791a57b33dd35b5792a60a4d436d2c761324a492a2c1R190-R198) [[3]](diffhunk://#diff-65845b92f5ee07169285791a57b33dd35b5792a60a4d436d2c761324a492a2c1L162-R162)