### PR TITLE
Point to the latest cre-sdk release on npm

### DIFF
--- a/cmd/creinit/template/workflow/typescriptPorExampleDev/package.json.tpl
+++ b/cmd/creinit/template/workflow/typescriptPorExampleDev/package.json.tpl
@@ -8,7 +8,7 @@
   },
   "license": "UNLICENSED",
   "dependencies": {
-    "@chainlink/cre-sdk": "^1.0.0",
+    "@chainlink/cre-sdk": "^1.0.1",
     "viem": "2.34.0",
     "zod": "3.25.76"
   },

--- a/cmd/creinit/template/workflow/typescriptSimpleExample/package.json.tpl
+++ b/cmd/creinit/template/workflow/typescriptSimpleExample/package.json.tpl
@@ -8,7 +8,7 @@
   },
   "license": "UNLICENSED",
   "dependencies": {
-    "@chainlink/cre-sdk": "^1.0.0"
+    "@chainlink/cre-sdk": "^1.0.1"
   },
   "devDependencies": {
     "@types/bun": "1.2.21"


### PR DESCRIPTION
Latest [cre-sdk](https://www.npmjs.com/package/@chainlink/cre-sdk) version is 1.0.1 and we should suggest that when starting new projects with TS. 