### PR TITLE
Maintain workflow status during upsert

### DIFF
--- a/cmd/workflow/deploy/deploy.go
+++ b/cmd/workflow/deploy/deploy.go
@@ -65,6 +65,10 @@ type handler struct {
 
 	validated bool
 
+	// existingWorkflowStatus stores the status of an existing workflow when updating.
+	// nil means this is a new workflow, otherwise it contains the current status (0=active, 1=paused).
+	existingWorkflowStatus *uint8
+
 	wg     sync.WaitGroup
 	wrcErr error
 }
@@ -246,6 +250,8 @@ func (h *handler) workflowExists() error {
 
 	}
 	if workflow.WorkflowName == h.inputs.WorkflowName {
+		status := workflow.Status
+		h.existingWorkflowStatus = &status
 		return fmt.Errorf("workflow with name %s already exists", h.inputs.WorkflowName)
 	}
 	return nil

--- a/cmd/workflow/deploy/register.go
+++ b/cmd/workflow/deploy/register.go
@@ -32,12 +32,18 @@ func (h *handler) prepareUpsertParams() (client.RegisterWorkflowV2Parameters, er
 	configURL := h.inputs.ResolveConfigURL("")
 	workflowID := h.workflowArtifact.WorkflowID
 
+	// Use the existing workflow's status if updating, otherwise default to active (0).
+	status := uint8(0)
+	if h.existingWorkflowStatus != nil {
+		status = *h.existingWorkflowStatus
+	}
+
 	fmt.Printf("Preparing transaction for workflowID: %s\n", workflowID)
 	return client.RegisterWorkflowV2Parameters{
 		WorkflowName: workflowName,
 		Tag:          workflowTag,
 		WorkflowID:   [32]byte(common.Hex2Bytes(workflowID)),
-		Status:       0, // active
+		Status:       status,
 		DonFamily:    h.inputs.DonFamily,
 		BinaryURL:    binaryURL,
 		ConfigURL:    configURL,

--- a/cmd/workflow/deploy/register_test.go
+++ b/cmd/workflow/deploy/register_test.go
@@ -4,6 +4,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/cre-cli/internal/testutil/chainsim"
@@ -67,5 +68,106 @@ func TestWorkflowUpsert(t *testing.T) {
 				require.NoError(t, err)
 			})
 		}
+	})
+}
+
+func TestPrepareUpsertParams_StatusPreservation(t *testing.T) {
+	t.Run("new workflow uses active status by default", func(t *testing.T) {
+		t.Parallel()
+		simulatedEnvironment := chainsim.NewSimulatedEnvironment(t)
+		defer simulatedEnvironment.Close()
+
+		ctx, buf := simulatedEnvironment.NewRuntimeContextWithBufferedOutput()
+		handler := newHandler(ctx, buf)
+
+		handler.inputs = Inputs{
+			WorkflowName:                      "test_workflow",
+			WorkflowOwner:                     chainsim.TestAddress,
+			WorkflowPath:                      filepath.Join("testdata", "basic_workflow", "main.go"),
+			DonFamily:                         "zone-a",
+			WorkflowRegistryContractChainName: "ethereum-testnet-sepolia",
+			WorkflowRegistryContractAddress:   simulatedEnvironment.Contracts.WorkflowRegistry.Contract.Hex(),
+			BinaryURL:                         "https://example.com/binary",
+			WorkflowTag:                       "test_tag",
+		}
+		handler.workflowArtifact = &workflowArtifact{
+			BinaryData: []byte("0x1234"),
+			ConfigData: []byte("config"),
+			WorkflowID: "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+		}
+		handler.validated = true
+
+		// No existing workflow status set (nil), so it should default to active (0)
+		params, err := handler.prepareUpsertParams()
+		require.NoError(t, err)
+		assert.Equal(t, uint8(0), params.Status, "new workflow should have active status (0)")
+	})
+
+	t.Run("updating paused workflow preserves paused status", func(t *testing.T) {
+		t.Parallel()
+		simulatedEnvironment := chainsim.NewSimulatedEnvironment(t)
+		defer simulatedEnvironment.Close()
+
+		ctx, buf := simulatedEnvironment.NewRuntimeContextWithBufferedOutput()
+		handler := newHandler(ctx, buf)
+
+		handler.inputs = Inputs{
+			WorkflowName:                      "test_workflow",
+			WorkflowOwner:                     chainsim.TestAddress,
+			WorkflowPath:                      filepath.Join("testdata", "basic_workflow", "main.go"),
+			DonFamily:                         "zone-a",
+			WorkflowRegistryContractChainName: "ethereum-testnet-sepolia",
+			WorkflowRegistryContractAddress:   simulatedEnvironment.Contracts.WorkflowRegistry.Contract.Hex(),
+			BinaryURL:                         "https://example.com/binary",
+			WorkflowTag:                       "test_tag",
+		}
+		handler.workflowArtifact = &workflowArtifact{
+			BinaryData: []byte("0x1234"),
+			ConfigData: []byte("config"),
+			WorkflowID: "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+		}
+		handler.validated = true
+
+		// Simulate existing workflow with paused status (1)
+		pausedStatus := uint8(1)
+		handler.existingWorkflowStatus = &pausedStatus
+
+		params, err := handler.prepareUpsertParams()
+		require.NoError(t, err)
+		assert.Equal(t, uint8(1), params.Status, "updating paused workflow should preserve paused status (1)")
+	})
+
+	t.Run("updating active workflow preserves active status", func(t *testing.T) {
+		t.Parallel()
+		simulatedEnvironment := chainsim.NewSimulatedEnvironment(t)
+		defer simulatedEnvironment.Close()
+
+		ctx, buf := simulatedEnvironment.NewRuntimeContextWithBufferedOutput()
+		handler := newHandler(ctx, buf)
+
+		handler.inputs = Inputs{
+			WorkflowName:                      "test_workflow",
+			WorkflowOwner:                     chainsim.TestAddress,
+			WorkflowPath:                      filepath.Join("testdata", "basic_workflow", "main.go"),
+			DonFamily:                         "zone-a",
+			WorkflowRegistryContractChainName: "ethereum-testnet-sepolia",
+			WorkflowRegistryContractAddress:   simulatedEnvironment.Contracts.WorkflowRegistry.Contract.Hex(),
+			BinaryURL:                         "https://example.com/binary",
+			WorkflowTag:                       "test_tag",
+		}
+		handler.workflowArtifact = &workflowArtifact{
+			BinaryData: []byte("0x1234"),
+			ConfigData: []byte("config"),
+			WorkflowID: "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+		}
+		handler.validated = true
+
+		// Simulate existing workflow with active status (0)
+		activeStatus := uint8(0)
+		handler.existingWorkflowStatus = &activeStatus
+
+		params, err := handler.prepareUpsertParams()
+		require.NoError(t, err)
+		assert.Equal(t, uint8(0), params.Status, "updating active workflow should preserve active status (0)")
 	})
 }


### PR DESCRIPTION
### JIRA https://smartcontract-it.atlassian.net/browse/DEVSVCS-3209

## Fix: Cannot deploy over paused workflow

### Problem
Deploying an update to a paused workflow failed with `CannotChangeStatusOnUpdate` because the CLI hardcoded `Status: 0` (active), but the contract requires the status to match the existing workflow.

### Solution
Preserve the existing workflow's status when upserting:
- Added `existingWorkflowStatus` field to capture status during `workflowExists()` check
- Use preserved status in `prepareUpsertParams()` instead of hardcoding active

### Testing
Added unit tests for status preservation on new and existing workflows.