### PR TITLE
Update `cre-sdk` in templates

### DIFF
--- a/cmd/creinit/template/workflow/typescriptConfHTTP/main.ts.tpl
+++ b/cmd/creinit/template/workflow/typescriptConfHTTP/main.ts.tpl
@@ -1,7 +1,9 @@
 import {
 	type ConfidentialHTTPSendRequester,
 	consensusIdenticalAggregation,
-	cre,
+	handler,
+	ConfidentialHTTPClient,
+	CronCapability,
 	json,
 	ok,
 	Runner,
@@ -58,7 +60,7 @@ const fetchResult = (sendRequester: ConfidentialHTTPSendRequester, config: Confi
 const onCronTrigger = (runtime: Runtime<Config>) => {
 	runtime.log('Confidential HTTP workflow triggered.')
 
-	const confHTTPClient = new cre.capabilities.ConfidentialHTTPClient()
+	const confHTTPClient = new ConfidentialHTTPClient()
 	const result = confHTTPClient
 		.sendRequests(
 			runtime,
@@ -75,9 +77,9 @@ const onCronTrigger = (runtime: Runtime<Config>) => {
 }
 
 const initWorkflow = (config: Config) => {
-	const cron = new cre.capabilities.CronCapability()
+	const cron = new CronCapability()
 
-	return [cre.handler(cron.trigger({ schedule: config.schedule }), onCronTrigger)]
+	return [handler(cron.trigger({ schedule: config.schedule }), onCronTrigger)]
 }
 
 export async function main() {
@@ -85,5 +87,3 @@ export async function main() {
 
 	await runner.run(initWorkflow)
 }
-
-main()

--- a/cmd/creinit/template/workflow/typescriptConfHTTP/package.json.tpl
+++ b/cmd/creinit/template/workflow/typescriptConfHTTP/package.json.tpl
@@ -8,7 +8,8 @@
   },
   "license": "UNLICENSED",
   "dependencies": {
-    "@chainlink/cre-sdk": "^1.0.0"
+    "@chainlink/cre-sdk": "^1.0.3",
+    "zod": "3.25.76"
   },
   "devDependencies": {
     "@types/bun": "1.2.21"

--- a/cmd/creinit/template/workflow/typescriptPorExampleDev/package.json.tpl
+++ b/cmd/creinit/template/workflow/typescriptPorExampleDev/package.json.tpl
@@ -8,7 +8,7 @@
   },
   "license": "UNLICENSED",
   "dependencies": {
-    "@chainlink/cre-sdk": "^1.0.1",
+    "@chainlink/cre-sdk": "^1.0.3",
     "viem": "2.34.0",
     "zod": "3.25.76"
   },

--- a/cmd/creinit/template/workflow/typescriptSimpleExample/main.ts.tpl
+++ b/cmd/creinit/template/workflow/typescriptSimpleExample/main.ts.tpl
@@ -1,4 +1,4 @@
-import { cre, Runner, type Runtime } from "@chainlink/cre-sdk";
+import { CronCapability, handler, Runner, type Runtime } from "@chainlink/cre-sdk";
 
 type Config = {
   schedule: string;
@@ -10,10 +10,10 @@ const onCronTrigger = (runtime: Runtime<Config>): string => {
 };
 
 const initWorkflow = (config: Config) => {
-  const cron = new cre.capabilities.CronCapability();
+  const cron = new CronCapability();
 
   return [
-    cre.handler(
+    handler(
       cron.trigger(
         { schedule: config.schedule }
       ), 
@@ -26,5 +26,3 @@ export async function main() {
   const runner = await Runner.newRunner<Config>();
   await runner.run(initWorkflow);
 }
-
-main();

--- a/cmd/creinit/template/workflow/typescriptSimpleExample/package.json.tpl
+++ b/cmd/creinit/template/workflow/typescriptSimpleExample/package.json.tpl
@@ -8,7 +8,7 @@
   },
   "license": "UNLICENSED",
   "dependencies": {
-    "@chainlink/cre-sdk": "^1.0.1"
+    "@chainlink/cre-sdk": "^1.0.3"
   },
   "devDependencies": {
     "@types/bun": "1.2.21"


### PR DESCRIPTION
- Update TS `cre-sdk` suggestion in starting templates (defaults to version 1.0.3 of `cre-sdk`)
- updates templates to use simpler workflow syntax
  - remove usage of `cre.capabilities.*` calls in favor of simpler imports
  - remove calling `main()` at the end of the workflow file as this is now handled automatically when compiling workflows 