### PR TITLE
fix: logic bug in template contract MessageEmitter.sol

### DIFF
--- a/cmd/creinit/template/workflow/porExampleDev/contracts/evm/src/MessageEmitter.sol.tpl
+++ b/cmd/creinit/template/workflow/porExampleDev/contracts/evm/src/MessageEmitter.sol.tpl
@@ -26,7 +26,7 @@ contract MessageEmitter is ITypeAndVersion {
 
   function getMessage(address emitter, uint256 timestamp) public view returns (string memory) {
     bytes32 key = _hashKey(emitter, timestamp);
-    require(bytes(s_messages[key]).length == 0, "Message does not exist for the given sender and timestamp");
+    require(bytes(s_messages[key]).length > 0, "Message does not exist for the given sender and timestamp");
     return s_messages[key];
   }
 


### PR DESCRIPTION
Identified in https://github.com/smartcontractkit/cre-workflows/pull/472#discussion_r2754016483

# Logic Bug in getMessage

## Location:

Solidity
```
function getMessage(address emitter, uint256 timestamp) public view returns (string memory) {
    bytes32 key = _hashKey(emitter, timestamp);
    require(bytes(s_messages[key]).length == 0, "Message does not exist for the given sender and timestamp");
    return s_messages[key];
}
```

## Problem:
The require checks that the message length is zero (== 0), and reverts with "Message does not exist for the given sender and timestamp".
But a message does exist only if the length is greater than 0. This logic is inverted: it's allowing "empty" messages and reverting if present.

## Fix:
The condition should be > 0, not == 0:

Solidity
```
require(bytes(s_messages[key]).length > 0, "Message does not exist for the given sender and timestamp");
```