### PR TITLE
Make default post install command bun x

### DIFF
--- a/cmd/creinit/template/workflow/typescriptConfHTTP/package.json.tpl
+++ b/cmd/creinit/template/workflow/typescriptConfHTTP/package.json.tpl
@@ -4,11 +4,11 @@
   "main": "dist/main.js",
   "private": true,
   "scripts": {
-    "postinstall": "bunx cre-setup"
+    "postinstall": "bun x cre-setup"
   },
   "license": "UNLICENSED",
   "dependencies": {
-    "@chainlink/cre-sdk": "^1.0.7",
+    "@chainlink/cre-sdk": "^1.0.8",
     "zod": "3.25.76"
   },
   "devDependencies": {

--- a/cmd/creinit/template/workflow/typescriptPorExampleDev/package.json.tpl
+++ b/cmd/creinit/template/workflow/typescriptPorExampleDev/package.json.tpl
@@ -4,11 +4,11 @@
   "main": "dist/main.js",
   "private": true,
   "scripts": {
-    "postinstall": "bunx cre-setup"
+    "postinstall": "bun x cre-setup"
   },
   "license": "UNLICENSED",
   "dependencies": {
-    "@chainlink/cre-sdk": "^1.0.7",
+    "@chainlink/cre-sdk": "^1.0.8",
     "viem": "2.34.0",
     "zod": "3.25.76"
   },

--- a/cmd/creinit/template/workflow/typescriptSimpleExample/package.json.tpl
+++ b/cmd/creinit/template/workflow/typescriptSimpleExample/package.json.tpl
@@ -4,11 +4,11 @@
   "main": "dist/main.js",
   "private": true,
   "scripts": {
-    "postinstall": "bunx cre-setup"
+    "postinstall": "bun x cre-setup"
   },
   "license": "UNLICENSED",
   "dependencies": {
-    "@chainlink/cre-sdk": "^1.0.7"
+    "@chainlink/cre-sdk": "^1.0.8"
   },
   "devDependencies": {
     "@types/bun": "1.2.21"

--- a/install/install.ps1
+++ b/install/install.ps1
@@ -79,7 +79,7 @@ function Test-GoDependency {
 function Test-BunDependency {
     if (-not (Get-Command bun -ErrorAction SilentlyContinue)) {
         Write-Warning "'bun' is not installed."
-        Write-Host "         Bun $RequiredBunVersion or later is recommended to run TypeScript CRE workflows (e.g. 'postinstall: bunx cre-setup')."
+        Write-Host "         Bun $RequiredBunVersion or later is recommended to run TypeScript CRE workflows (e.g. 'postinstall: bun x cre-setup')."
         return
     }
 

--- a/install/install.sh
+++ b/install/install.sh
@@ -67,11 +67,11 @@ check_go_dependency() {
   fi
 }
 
-# Check Bun dependency and version (for TypeScript workflows using 'bunx cre-setup').
+# Check Bun dependency and version (for TypeScript workflows using 'bun x cre-setup').
 check_bun_dependency() {
   if ! command -v bun >/dev/null 2>&1; then
     echo "Warning: 'bun' is not installed."
-    echo "         Bun $REQUIRED_BUN_VERSION or later is recommended to run TypeScript CRE workflows (e.g. 'postinstall: bunx cre-setup')."
+    echo "         Bun $REQUIRED_BUN_VERSION or later is recommended to run TypeScript CRE workflows (e.g. 'postinstall: bun x cre-setup')."
     return
   fi
 


### PR DESCRIPTION
- updates default `cre-sdk` version to `1.0.8`
- changes the `post-install` command to `bun x` (previously `bunx`). 

`bunx` was just an alias for `bun x` ([docs](https://bun.com/docs/pm/bunx)) and it had some issues working out of the box for Windows users. `bun x` works well cross-platform. 

This change has been manually tested by running `make build` in `cre-cli` and using that to init new TypeScript workflow. 

<img width="1231" height="909" alt="Screenshot 2026-02-04 at 11 49 52" src="https://github.com/user-attachments/assets/877a45d2-bc48-43a9-bd38-8cdfaf107442" />
