### PR TITLE
Bump cre-sdk typescript

### DIFF
--- a/cmd/creinit/template/workflow/typescriptConfHTTP/package.json.tpl
+++ b/cmd/creinit/template/workflow/typescriptConfHTTP/package.json.tpl
@@ -8,7 +8,7 @@
   },
   "license": "UNLICENSED",
   "dependencies": {
-    "@chainlink/cre-sdk": "^1.0.8",
+    "@chainlink/cre-sdk": "^1.0.9",
     "zod": "3.25.76"
   },
   "devDependencies": {

--- a/cmd/creinit/template/workflow/typescriptPorExampleDev/package.json.tpl
+++ b/cmd/creinit/template/workflow/typescriptPorExampleDev/package.json.tpl
@@ -8,7 +8,7 @@
   },
   "license": "UNLICENSED",
   "dependencies": {
-    "@chainlink/cre-sdk": "^1.0.8",
+    "@chainlink/cre-sdk": "^1.0.9",
     "viem": "2.34.0",
     "zod": "3.25.76"
   },

--- a/cmd/creinit/template/workflow/typescriptSimpleExample/package.json.tpl
+++ b/cmd/creinit/template/workflow/typescriptSimpleExample/package.json.tpl
@@ -8,7 +8,7 @@
   },
   "license": "UNLICENSED",
   "dependencies": {
-    "@chainlink/cre-sdk": "^1.0.8"
+    "@chainlink/cre-sdk": "^1.0.9"
   },
   "devDependencies": {
     "@types/bun": "1.2.21"


### PR DESCRIPTION
Suggest `cre-sdk@1.0.9` as default in typescript templates.