### PR TITLE
Fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -407,6 +407,7 @@ jobs:
     permissions:
       actions: read
       contents: write
+      id-token: write
     steps:
       - name: Download Build Artifacts for linux/amd64
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # actions/download-artifact@v4.1.8


### PR DESCRIPTION
Fix for [https://github.com/smartcontractkit/cre-cli/security/code-scanning/2](https://github.com/smartcontractkit/cre-cli/security/code-scanning/2)

Adding 
```
    permissions:
      actions: read
      contents: write
```
for release action.

actions: read → needed to download workflow artifacts
contents: write → needed to create the GitHub Release and upload release assets