### PR TITLE
Confidential workflow support via workflow.yaml

### DIFF
--- a/cmd/client/workflow_registry_v2_client.go
+++ b/cmd/client/workflow_registry_v2_client.go
@@ -39,7 +39,7 @@ type RegisterWorkflowV2Parameters struct {
 
 	BinaryURL  string // required: URL location for the workflow binary WASM file
 	ConfigURL  string // optional: URL location for the workflow configuration file (default empty string)
-	Attributes []byte // optional: 1 to pause workflow after registration, 0 to activate it (default is 0)
+	Attributes []byte // optional: JSON-encoded workflow attributes (e.g. confidential flag, vault secrets)
 	KeepAlive  bool   // optional: whether to keep the other workflows of the same name and owner active after the new deploy (default is false)
 }
 

--- a/cmd/client/workflow_registry_v2_client.go
+++ b/cmd/client/workflow_registry_v2_client.go
@@ -39,7 +39,7 @@ type RegisterWorkflowV2Parameters struct {
 
 	BinaryURL  string // required: URL location for the workflow binary WASM file
 	ConfigURL  string // optional: URL location for the workflow configuration file (default empty string)
-	Attributes []byte // optional: JSON-encoded workflow attributes (e.g. confidential flag, vault secrets)
+	Attributes []byte // optional: JSON-encoded workflow attributes (e.g. confidential flag, enclave type)
 	KeepAlive  bool   // optional: whether to keep the other workflows of the same name and owner active after the new deploy (default is false)
 }
 

--- a/cmd/workflow/deploy/deploy.go
+++ b/cmd/workflow/deploy/deploy.go
@@ -187,6 +187,13 @@ func (h *handler) ValidateInputs() error {
 		return fmt.Errorf("--secret requires --confidential flag")
 	}
 
+	for _, s := range h.inputs.Secrets {
+		key, _, _ := strings.Cut(s, ":")
+		if strings.TrimSpace(key) == "" {
+			return fmt.Errorf("--secret value %q has empty key", s)
+		}
+	}
+
 	validate, err := validation.NewValidator()
 	if err != nil {
 		return fmt.Errorf("failed to initialize validator: %w", err)

--- a/cmd/workflow/deploy/deploy.go
+++ b/cmd/workflow/deploy/deploy.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"strings"
 	"sync"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -42,6 +43,9 @@ type Inputs struct {
 
 	OwnerLabel       string `validate:"omitempty"`
 	SkipConfirmation bool
+
+	Confidential bool
+	Secrets      []string
 }
 
 func (i *Inputs) ResolveConfigURL(fallbackURL string) string {
@@ -104,6 +108,8 @@ func New(runtimeContext *runtime.Context) *cobra.Command {
 	settings.AddSkipConfirmation(deployCmd)
 	deployCmd.Flags().StringP("output", "o", defaultOutputPath, "The output file for the compiled WASM binary encoded in base64")
 	deployCmd.Flags().StringP("owner-label", "l", "", "Label for the workflow owner (used during auto-link if owner is not already linked)")
+	deployCmd.Flags().Bool("confidential", false, "Deploy as a confidential workflow (runs in enclave)")
+	deployCmd.Flags().StringSlice("secret", nil, "VaultDON secret to request (repeatable, format: KEY or KEY:namespace)")
 
 	return deployCmd
 }
@@ -171,10 +177,16 @@ func (h *handler) ResolveInputs(v *viper.Viper) (Inputs, error) {
 		WorkflowRegistryContractAddress:   h.environmentSet.WorkflowRegistryAddress,
 		OwnerLabel:                        v.GetString("owner-label"),
 		SkipConfirmation:                  v.GetBool(settings.Flags.SkipConfirmation.Name),
+		Confidential:                      v.GetBool("confidential"),
+		Secrets:                           v.GetStringSlice("secret"),
 	}, nil
 }
 
 func (h *handler) ValidateInputs() error {
+	if len(h.inputs.Secrets) > 0 && !h.inputs.Confidential {
+		return fmt.Errorf("--secret requires --confidential flag")
+	}
+
 	validate, err := validation.NewValidator()
 	if err != nil {
 		return fmt.Errorf("failed to initialize validator: %w", err)
@@ -299,5 +311,11 @@ func (h *handler) displayWorkflowDetails() {
 	ui.Title(fmt.Sprintf("Deploying Workflow: %s", h.inputs.WorkflowName))
 	ui.Dim(fmt.Sprintf("Target:        %s", h.settings.User.TargetName))
 	ui.Dim(fmt.Sprintf("Owner Address: %s", h.settings.Workflow.UserWorkflowSettings.WorkflowOwnerAddress))
+	if h.inputs.Confidential {
+		ui.Dim("Confidential:  yes")
+		if len(h.inputs.Secrets) > 0 {
+			ui.Dim(fmt.Sprintf("Secrets:       %s", strings.Join(h.inputs.Secrets, ", ")))
+		}
+	}
 	ui.Line()
 }

--- a/cmd/workflow/deploy/deploy.go
+++ b/cmd/workflow/deploy/deploy.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"strings"
 	"sync"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -44,8 +43,7 @@ type Inputs struct {
 	OwnerLabel       string `validate:"omitempty"`
 	SkipConfirmation bool
 
-	Confidential bool
-	Secrets      []string
+	Enclave string // enclave type (e.g. "nitro"); empty means non-confidential
 }
 
 func (i *Inputs) ResolveConfigURL(fallbackURL string) string {
@@ -108,8 +106,7 @@ func New(runtimeContext *runtime.Context) *cobra.Command {
 	settings.AddSkipConfirmation(deployCmd)
 	deployCmd.Flags().StringP("output", "o", defaultOutputPath, "The output file for the compiled WASM binary encoded in base64")
 	deployCmd.Flags().StringP("owner-label", "l", "", "Label for the workflow owner (used during auto-link if owner is not already linked)")
-	deployCmd.Flags().Bool("confidential", false, "Deploy as a confidential workflow (runs in enclave)")
-	deployCmd.Flags().StringSlice("secret", nil, "VaultDON secret to request (repeatable, format: KEY or KEY:namespace)")
+	deployCmd.Flags().String("enclave", "", "Enclave type for confidential execution (e.g. \"nitro\"); prefer setting confidential.enclave in workflow.yaml")
 
 	return deployCmd
 }
@@ -177,22 +174,19 @@ func (h *handler) ResolveInputs(v *viper.Viper) (Inputs, error) {
 		WorkflowRegistryContractAddress:   h.environmentSet.WorkflowRegistryAddress,
 		OwnerLabel:                        v.GetString("owner-label"),
 		SkipConfirmation:                  v.GetBool(settings.Flags.SkipConfirmation.Name),
-		Confidential:                      v.GetBool("confidential"),
-		Secrets:                           v.GetStringSlice("secret"),
+		Enclave:                           h.resolveEnclave(v),
 	}, nil
 }
 
-func (h *handler) ValidateInputs() error {
-	if len(h.inputs.Secrets) > 0 && !h.inputs.Confidential {
-		return fmt.Errorf("--secret requires --confidential flag")
+// resolveEnclave returns the enclave type from workflow.yaml, overridden by CLI flag.
+func (h *handler) resolveEnclave(v *viper.Viper) string {
+	if cli := v.GetString("enclave"); cli != "" {
+		return cli
 	}
+	return h.settings.Workflow.ConfidentialSettings.Enclave
+}
 
-	for _, s := range h.inputs.Secrets {
-		key, _, _ := strings.Cut(s, ":")
-		if strings.TrimSpace(key) == "" {
-			return fmt.Errorf("--secret value %q has empty key", s)
-		}
-	}
+func (h *handler) ValidateInputs() error {
 
 	validate, err := validation.NewValidator()
 	if err != nil {
@@ -318,11 +312,8 @@ func (h *handler) displayWorkflowDetails() {
 	ui.Title(fmt.Sprintf("Deploying Workflow: %s", h.inputs.WorkflowName))
 	ui.Dim(fmt.Sprintf("Target:        %s", h.settings.User.TargetName))
 	ui.Dim(fmt.Sprintf("Owner Address: %s", h.settings.Workflow.UserWorkflowSettings.WorkflowOwnerAddress))
-	if h.inputs.Confidential {
-		ui.Dim("Confidential:  yes")
-		if len(h.inputs.Secrets) > 0 {
-			ui.Dim(fmt.Sprintf("Secrets:       %s", strings.Join(h.inputs.Secrets, ", ")))
-		}
+	if h.inputs.Enclave != "" {
+		ui.Dim(fmt.Sprintf("Enclave:       %s", h.inputs.Enclave))
 	}
 	ui.Line()
 }

--- a/cmd/workflow/deploy/deploy_test.go
+++ b/cmd/workflow/deploy/deploy_test.go
@@ -228,31 +228,6 @@ func TestResolveInputs_TagTruncation(t *testing.T) {
 	}
 }
 
-func TestValidateInputs_SecretRequiresConfidential(t *testing.T) {
-	t.Parallel()
-	simulatedEnvironment := chainsim.NewSimulatedEnvironment(t)
-	defer simulatedEnvironment.Close()
-
-	ctx, buf := simulatedEnvironment.NewRuntimeContextWithBufferedOutput()
-	h := newHandler(ctx, buf)
-
-	h.inputs = Inputs{
-		WorkflowName:                      "test_workflow",
-		WorkflowOwner:                     chainsim.TestAddress,
-		WorkflowPath:                      "testdata/basic_workflow/main.go",
-		DonFamily:                         "zone-a",
-		WorkflowRegistryContractChainName: "ethereum-testnet-sepolia",
-		WorkflowRegistryContractAddress:   simulatedEnvironment.Contracts.WorkflowRegistry.Contract.Hex(),
-		Secrets:                           []string{"API_KEY"},
-		Confidential:                      false,
-	}
-
-	err := h.ValidateInputs()
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "--secret requires --confidential flag")
-	assert.False(t, h.validated)
-}
-
 func stringPtr(s string) *string {
 	return &s
 }

--- a/cmd/workflow/deploy/register.go
+++ b/cmd/workflow/deploy/register.go
@@ -4,7 +4,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -154,22 +153,13 @@ func (h *handler) handleUpsert(params client.RegisterWorkflowV2Parameters) error
 }
 
 func (h *handler) buildAttributes() ([]byte, error) {
-	if !h.inputs.Confidential {
+	if h.inputs.Enclave == "" {
 		return []byte{}, nil
 	}
 
-	secrets := make([]secretIdentifier, 0, len(h.inputs.Secrets))
-	for _, s := range h.inputs.Secrets {
-		key, ns, _ := strings.Cut(s, ":")
-		secrets = append(secrets, secretIdentifier{
-			Key:       key,
-			Namespace: ns,
-		})
-	}
-
 	attrs := workflowAttributes{
-		Confidential:    true,
-		VaultDonSecrets: secrets,
+		Confidential: true,
+		Enclave:      h.inputs.Enclave,
 	}
 
 	data, err := json.Marshal(attrs)
@@ -180,11 +170,6 @@ func (h *handler) buildAttributes() ([]byte, error) {
 }
 
 type workflowAttributes struct {
-	Confidential    bool               `json:"confidential"`
-	VaultDonSecrets []secretIdentifier `json:"vault_don_secrets,omitempty"`
-}
-
-type secretIdentifier struct {
-	Key       string `json:"key"`
-	Namespace string `json:"namespace,omitempty"`
+	Confidential bool   `json:"confidential"`
+	Enclave      string `json:"enclave,omitempty"`
 }

--- a/cmd/workflow/deploy/register_test.go
+++ b/cmd/workflow/deploy/register_test.go
@@ -179,14 +179,16 @@ func TestBuildAttributes(t *testing.T) {
 	t.Run("non-confidential workflow returns empty attributes", func(t *testing.T) {
 		t.Parallel()
 		h := &handler{inputs: Inputs{Confidential: false}}
-		attrs := h.buildAttributes()
+		attrs, err := h.buildAttributes()
+		require.NoError(t, err)
 		assert.Equal(t, []byte{}, attrs)
 	})
 
 	t.Run("confidential workflow with no secrets", func(t *testing.T) {
 		t.Parallel()
 		h := &handler{inputs: Inputs{Confidential: true}}
-		attrs := h.buildAttributes()
+		attrs, err := h.buildAttributes()
+		require.NoError(t, err)
 
 		var parsed workflowAttributes
 		require.NoError(t, json.Unmarshal(attrs, &parsed))
@@ -200,7 +202,8 @@ func TestBuildAttributes(t *testing.T) {
 			Confidential: true,
 			Secrets:      []string{"API_KEY", "DB_PASS"},
 		}}
-		attrs := h.buildAttributes()
+		attrs, err := h.buildAttributes()
+		require.NoError(t, err)
 
 		var parsed workflowAttributes
 		require.NoError(t, json.Unmarshal(attrs, &parsed))
@@ -218,7 +221,8 @@ func TestBuildAttributes(t *testing.T) {
 			Confidential: true,
 			Secrets:      []string{"API_KEY:prod", "DB_PASS"},
 		}}
-		attrs := h.buildAttributes()
+		attrs, err := h.buildAttributes()
+		require.NoError(t, err)
 
 		var parsed workflowAttributes
 		require.NoError(t, json.Unmarshal(attrs, &parsed))

--- a/cmd/workflow/deploy/register_test.go
+++ b/cmd/workflow/deploy/register_test.go
@@ -1,6 +1,7 @@
 package deploy
 
 import (
+	"encoding/json"
 	"path/filepath"
 	"testing"
 
@@ -169,5 +170,62 @@ func TestPrepareUpsertParams_StatusPreservation(t *testing.T) {
 		params, err := handler.prepareUpsertParams()
 		require.NoError(t, err)
 		assert.Equal(t, uint8(0), params.Status, "updating active workflow should preserve active status (0)")
+	})
+}
+
+func TestBuildAttributes(t *testing.T) {
+	t.Parallel()
+
+	t.Run("non-confidential workflow returns empty attributes", func(t *testing.T) {
+		t.Parallel()
+		h := &handler{inputs: Inputs{Confidential: false}}
+		attrs := h.buildAttributes()
+		assert.Equal(t, []byte{}, attrs)
+	})
+
+	t.Run("confidential workflow with no secrets", func(t *testing.T) {
+		t.Parallel()
+		h := &handler{inputs: Inputs{Confidential: true}}
+		attrs := h.buildAttributes()
+
+		var parsed workflowAttributes
+		require.NoError(t, json.Unmarshal(attrs, &parsed))
+		assert.True(t, parsed.Confidential)
+		assert.Empty(t, parsed.VaultDonSecrets)
+	})
+
+	t.Run("confidential workflow with secrets", func(t *testing.T) {
+		t.Parallel()
+		h := &handler{inputs: Inputs{
+			Confidential: true,
+			Secrets:      []string{"API_KEY", "DB_PASS"},
+		}}
+		attrs := h.buildAttributes()
+
+		var parsed workflowAttributes
+		require.NoError(t, json.Unmarshal(attrs, &parsed))
+		assert.True(t, parsed.Confidential)
+		require.Len(t, parsed.VaultDonSecrets, 2)
+		assert.Equal(t, "API_KEY", parsed.VaultDonSecrets[0].Key)
+		assert.Empty(t, parsed.VaultDonSecrets[0].Namespace)
+		assert.Equal(t, "DB_PASS", parsed.VaultDonSecrets[1].Key)
+		assert.Empty(t, parsed.VaultDonSecrets[1].Namespace)
+	})
+
+	t.Run("secret with namespace parsed correctly", func(t *testing.T) {
+		t.Parallel()
+		h := &handler{inputs: Inputs{
+			Confidential: true,
+			Secrets:      []string{"API_KEY:prod", "DB_PASS"},
+		}}
+		attrs := h.buildAttributes()
+
+		var parsed workflowAttributes
+		require.NoError(t, json.Unmarshal(attrs, &parsed))
+		require.Len(t, parsed.VaultDonSecrets, 2)
+		assert.Equal(t, "API_KEY", parsed.VaultDonSecrets[0].Key)
+		assert.Equal(t, "prod", parsed.VaultDonSecrets[0].Namespace)
+		assert.Equal(t, "DB_PASS", parsed.VaultDonSecrets[1].Key)
+		assert.Empty(t, parsed.VaultDonSecrets[1].Namespace)
 	})
 }

--- a/cmd/workflow/deploy/register_test.go
+++ b/cmd/workflow/deploy/register_test.go
@@ -178,58 +178,21 @@ func TestBuildAttributes(t *testing.T) {
 
 	t.Run("non-confidential workflow returns empty attributes", func(t *testing.T) {
 		t.Parallel()
-		h := &handler{inputs: Inputs{Confidential: false}}
+		h := &handler{inputs: Inputs{Enclave: ""}}
 		attrs, err := h.buildAttributes()
 		require.NoError(t, err)
 		assert.Equal(t, []byte{}, attrs)
 	})
 
-	t.Run("confidential workflow with no secrets", func(t *testing.T) {
+	t.Run("nitro enclave sets confidential and enclave type", func(t *testing.T) {
 		t.Parallel()
-		h := &handler{inputs: Inputs{Confidential: true}}
+		h := &handler{inputs: Inputs{Enclave: "nitro"}}
 		attrs, err := h.buildAttributes()
 		require.NoError(t, err)
 
 		var parsed workflowAttributes
 		require.NoError(t, json.Unmarshal(attrs, &parsed))
 		assert.True(t, parsed.Confidential)
-		assert.Empty(t, parsed.VaultDonSecrets)
-	})
-
-	t.Run("confidential workflow with secrets", func(t *testing.T) {
-		t.Parallel()
-		h := &handler{inputs: Inputs{
-			Confidential: true,
-			Secrets:      []string{"API_KEY", "DB_PASS"},
-		}}
-		attrs, err := h.buildAttributes()
-		require.NoError(t, err)
-
-		var parsed workflowAttributes
-		require.NoError(t, json.Unmarshal(attrs, &parsed))
-		assert.True(t, parsed.Confidential)
-		require.Len(t, parsed.VaultDonSecrets, 2)
-		assert.Equal(t, "API_KEY", parsed.VaultDonSecrets[0].Key)
-		assert.Empty(t, parsed.VaultDonSecrets[0].Namespace)
-		assert.Equal(t, "DB_PASS", parsed.VaultDonSecrets[1].Key)
-		assert.Empty(t, parsed.VaultDonSecrets[1].Namespace)
-	})
-
-	t.Run("secret with namespace parsed correctly", func(t *testing.T) {
-		t.Parallel()
-		h := &handler{inputs: Inputs{
-			Confidential: true,
-			Secrets:      []string{"API_KEY:prod", "DB_PASS"},
-		}}
-		attrs, err := h.buildAttributes()
-		require.NoError(t, err)
-
-		var parsed workflowAttributes
-		require.NoError(t, json.Unmarshal(attrs, &parsed))
-		require.Len(t, parsed.VaultDonSecrets, 2)
-		assert.Equal(t, "API_KEY", parsed.VaultDonSecrets[0].Key)
-		assert.Equal(t, "prod", parsed.VaultDonSecrets[0].Namespace)
-		assert.Equal(t, "DB_PASS", parsed.VaultDonSecrets[1].Key)
-		assert.Empty(t, parsed.VaultDonSecrets[1].Namespace)
+		assert.Equal(t, "nitro", parsed.Enclave)
 	})
 }

--- a/internal/settings/settings_load.go
+++ b/internal/settings/settings_load.go
@@ -19,6 +19,7 @@ const (
 	ConfigPathSettingName         = "workflow-artifacts.config-path"
 	SecretsPathSettingName        = "workflow-artifacts.secrets-path"
 	SethConfigPathSettingName     = "logging.seth-config-path"
+	ConfidentialEnclaveSettingName = "confidential.enclave"
 	RegistriesSettingName         = "contracts.registries"
 	KeystoneSettingName           = "contracts.keystone"
 	RpcsSettingName               = "rpcs"

--- a/internal/settings/template/workflow.yaml.tpl
+++ b/internal/settings/template/workflow.yaml.tpl
@@ -13,6 +13,8 @@
 #     workflow-path: "./main.ts"            # Path to workflow entry point
 #     config-path: "./config.yaml"          # Path to config file
 #     secrets-path: "../secrets.yaml"       # Path to secrets file (project root by default)
+#   confidential:                           # Optional: run workflow in a TEE
+#     enclave: "nitro"                      # Enclave type (e.g. "nitro")
 
 # ==========================================================================
 staging-settings:

--- a/internal/settings/workflow_settings.go
+++ b/internal/settings/workflow_settings.go
@@ -89,10 +89,18 @@ type WorkflowSettings struct {
 		ConfigPath   string `mapstructure:"config-path" yaml:"config-path"`
 		SecretsPath  string `mapstructure:"secrets-path" yaml:"secrets-path"`
 	} `mapstructure:"workflow-artifacts" yaml:"workflow-artifacts"`
+	ConfidentialSettings struct {
+		Enclave string `mapstructure:"enclave" yaml:"enclave"`
+	} `mapstructure:"confidential" yaml:"confidential"`
 	LoggingSettings struct {
 		SethConfigPath string `mapstructure:"seth-config-path" yaml:"seth-config-path"`
 	} `mapstructure:"logging" yaml:"logging"`
 	RPCs []RpcEndpoint `mapstructure:"rpcs" yaml:"rpcs"`
+}
+
+// IsConfidential returns true if the workflow has a non-empty enclave setting.
+func (w *WorkflowSettings) IsConfidential() bool {
+	return w.ConfidentialSettings.Enclave != ""
 }
 
 func loadWorkflowSettings(logger *zerolog.Logger, v *viper.Viper, cmd *cobra.Command, registryChainName string) (WorkflowSettings, error) {
@@ -131,6 +139,7 @@ func loadWorkflowSettings(logger *zerolog.Logger, v *viper.Viper, cmd *cobra.Com
 	workflowSettings.WorkflowArtifactSettings.ConfigPath = getSetting(ConfigPathSettingName)
 	workflowSettings.WorkflowArtifactSettings.SecretsPath = getSetting(SecretsPathSettingName)
 	workflowSettings.LoggingSettings.SethConfigPath = getSetting(SethConfigPathSettingName)
+	workflowSettings.ConfidentialSettings.Enclave = getSetting(ConfidentialEnclaveSettingName)
 	fullRPCsKey := fmt.Sprintf("%s.%s", target, RpcsSettingName)
 	if v.IsSet(fullRPCsKey) {
 		if err := v.UnmarshalKey(fullRPCsKey, &workflowSettings.RPCs); err != nil {


### PR DESCRIPTION
## Summary

Workflow authors declare confidential execution in `workflow.yaml` instead of remembering CLI flags. The enclave type is a string (not a boolean) so we can add GCP TEE support later without changing the author-facing interface.

Secrets are fetched at runtime via `get_secrets` calls in WASM. No upfront secrets declaration in the deploy config. Relay DON validates attestation and PCR measurements only.

## Usage

**workflow.yaml:**
```yaml
production-settings:
  user-workflow:
    workflow-name: "my-confidential-workflow"
  workflow-artifacts:
    workflow-path: "./main.ts"
    config-path: "./config.production.json"
    secrets-path: ""
  confidential:
    enclave: "nitro"
```

Then deploy as usual:
```bash
cre workflow deploy
```

The `--enclave` CLI flag is available as an override for testing:
```bash
cre workflow deploy --enclave nitro
```

## On-chain attributes

The deploy command sets the following JSON in the workflow registry's `attributes` field:
```json
{"confidential": true, "enclave": "nitro"}
```

The core node reads `confidential: true` to route to the `ConfidentialModule` (chainlink PR #21641). The `enclave` field is stored for future use.