### PR TITLE
chore: replace cre.chain.link with app.chain.link

### DIFF
--- a/install/install.ps1
+++ b/install/install.ps1
@@ -3,7 +3,7 @@
 # It detects the architecture, downloads the correct .exe,
 # and adds it to the user's PATH.
 #
-# Usage: irm https://cre.chain.link/install.ps1 | iex
+# Usage: irm https://app.chain.link/install.ps1 | iex
 
 # --- Configuration ---
 $ErrorActionPreference = "Stop" # Exit script on any error

--- a/install/install.sh
+++ b/install/install.sh
@@ -3,7 +3,7 @@
 # This is a universal installer script for 'cre'.
 # It detects the OS and architecture, then downloads the correct binary.
 #
-# Usage: curl -sSL https://cre.chain.link/install.sh | bash
+# Usage: curl -sSL https://app.chain.link/install.sh | bash
 
 set -e # Exit immediately if a command exits with a non-zero status.
 


### PR DESCRIPTION
The self-serve portal domain has moved from cre.chain.link to app.chain.link to support multiple BCM products.