### PR TITLE
Fix EVM Bindings generator struct prefix bug

### DIFF
--- a/cmd/generate-bindings/bindings/abigen/bindv2.go
+++ b/cmd/generate-bindings/bindings/abigen/bindv2.go
@@ -380,7 +380,7 @@ func BindV2(types []string, abis []string, bytecodes []string, pkg string, libs 
 	return string(code), nil
 }
 
-// Remove contract name prefixes from struct names
+// Remove contract name prefixes from struct names and update field type references.
 func sanitizeStructNames(structs map[string]*tmplStruct, contracts map[string]*tmplContractV2) {
 	contractNames := make([]string, 0, len(contracts))
 	for name := range contracts {
@@ -388,9 +388,22 @@ func sanitizeStructNames(structs map[string]*tmplStruct, contracts map[string]*t
 	}
 	sort.Strings(contractNames)
 
-	for _, structName := range structs {
+	renames := make(map[string]string)
+	for _, s := range structs {
+		original := s.Name
 		for _, contractName := range contractNames {
-			structName.Name = strings.TrimPrefix(structName.Name, contractName)
+			s.Name = strings.TrimPrefix(s.Name, contractName)
+		}
+		if s.Name != original {
+			renames[original] = s.Name
+		}
+	}
+
+	for _, s := range structs {
+		for _, f := range s.Fields {
+			for old, renamed := range renames {
+				f.Type = strings.ReplaceAll(f.Type, old, renamed)
+			}
 		}
 	}
 }

--- a/cmd/generate-bindings/generate-bindings_test.go
+++ b/cmd/generate-bindings/generate-bindings_test.go
@@ -1065,3 +1065,61 @@ func TestGenerateBindings_UnconventionalNaming(t *testing.T) {
 		})
 	}
 }
+
+func TestGenerateBindings_StructNamePrefixStripping(t *testing.T) {
+	// ABI where internalType embeds the contract name as a namespace prefix
+	// (e.g. "struct MyContract.Config"). go-ethereum folds the dot so the Go
+	// name becomes "MyContractConfig". sanitizeStructNames must strip the
+	// prefix from both struct declarations and field type references.
+	contractABI := `[
+		{
+			"type": "function",
+			"name": "getDON",
+			"inputs": [],
+			"outputs": [{
+				"name": "",
+				"type": "tuple",
+				"internalType": "struct MyContract.DONInfo",
+				"components": [
+					{"name": "id", "type": "uint32"},
+					{
+						"name": "capabilityConfigurations",
+						"type": "tuple[]",
+						"internalType": "struct MyContract.CapabilityConfiguration[]",
+						"components": [
+							{"name": "capabilityId", "type": "string"},
+							{"name": "config", "type": "bytes"}
+						]
+					}
+				]
+			}],
+			"stateMutability": "view"
+		}
+	]`
+
+	tempDir, err := os.MkdirTemp("", "bindings-prefix-test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tempDir)
+
+	abiFile := filepath.Join(tempDir, "MyContract.abi")
+	err = os.WriteFile(abiFile, []byte(contractABI), 0600)
+	require.NoError(t, err)
+
+	outFile := filepath.Join(tempDir, "bindings.go")
+	err = bindings.GenerateBindings("", abiFile, "mycontract", "MyContract", outFile)
+	require.NoError(t, err)
+
+	content, err := os.ReadFile(outFile)
+	require.NoError(t, err)
+	src := string(content)
+
+	// Struct declarations should have the prefix stripped.
+	assert.Contains(t, src, "type DONInfo struct")
+	assert.Contains(t, src, "type CapabilityConfiguration struct")
+	assert.NotContains(t, src, "type MyContractDONInfo struct")
+	assert.NotContains(t, src, "type MyContractCapabilityConfiguration struct")
+
+	// Field type references inside structs should also be stripped.
+	assert.Contains(t, src, "[]CapabilityConfiguration")
+	assert.NotContains(t, src, "[]MyContractCapabilityConfiguration")
+}


### PR DESCRIPTION
Previously only `tmplStruct.Name` was being updated. `tmplField.Type` is set earlier in bindStructType as a plain string and is what the template uses for struct fields in sourcecre.go.tpl `({{.Type}})`, not the dynamic bindtype path used for method args.

So you could get:
`type Foo struct { ... }` ← name was stripped
`tems []MyContractFoo` ← field still pointed at the old name
That’s invalid Go and fails to compile.

Now we are sure to rename the old field names with the new names