### PR TITLE
feat: warn user when deploying over a paused workflow

### DIFF
--- a/cmd/workflow/deploy/deploy.go
+++ b/cmd/workflow/deploy/deploy.go
@@ -338,7 +338,14 @@ func (h *handler) Execute(ctx context.Context) error {
 	if err := h.upsert(); err != nil {
 		return fmt.Errorf("failed to register workflow: %w", err)
 	}
+	warnIfPausedWorkflowUpdate(h.existingWorkflowStatus)
 	return nil
+}
+
+func warnIfPausedWorkflowUpdate(status *uint8) {
+	if status != nil && *status == workflowStatusPaused {
+		ui.Warning("Your workflow is paused and has been updated")
+	}
 }
 
 func (h *handler) workflowExists() error {

--- a/cmd/workflow/deploy/deploy_test.go
+++ b/cmd/workflow/deploy/deploy_test.go
@@ -1,9 +1,12 @@
 package deploy
 
 import (
+	"bytes"
 	"errors"
 	"io"
 	"math/big"
+	"os"
+	"strings"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -452,6 +455,47 @@ func (f fakeUserDonLimitClient) CheckUserDonLimit(owner common.Address, donFamil
 
 func (f fakeUserDonLimitClient) GetWorkflowListByOwnerAndName(common.Address, string, *big.Int, *big.Int) ([]workflow_registry_v2_wrapper.WorkflowRegistryWorkflowMetadataView, error) {
 	return f.workflowsByOwnerName, nil
+}
+
+func TestWarnExistingPausedWorkflowUpdate(t *testing.T) {
+	// Do not use t.Parallel: stderr redirection uses package-global os.Stderr.
+
+	captureStderr := func(f func()) string {
+		t.Helper()
+		old := os.Stderr
+		r, w, err := os.Pipe()
+		require.NoError(t, err)
+		os.Stderr = w
+
+		f()
+
+		require.NoError(t, w.Close())
+		os.Stderr = old
+
+		var buf bytes.Buffer
+		_, copyErr := io.Copy(&buf, r)
+		require.NoError(t, copyErr)
+		require.NoError(t, r.Close())
+		return buf.String()
+	}
+
+	t.Run("no output when status is nil", func(t *testing.T) {
+		out := captureStderr(func() { warnIfPausedWorkflowUpdate(nil) })
+		assert.Empty(t, strings.TrimSpace(out))
+	})
+
+	t.Run("no output when workflow is active", func(t *testing.T) {
+		active := workflowStatusActive
+		out := captureStderr(func() { warnIfPausedWorkflowUpdate(&active) })
+		assert.Empty(t, strings.TrimSpace(out))
+	})
+
+	t.Run("prints warning when workflow is paused", func(t *testing.T) {
+		paused := workflowStatusPaused
+		out := captureStderr(func() { warnIfPausedWorkflowUpdate(&paused) })
+		assert.Contains(t, out, "Your workflow is paused")
+		assert.Contains(t, out, "and has been updated")
+	})
 }
 
 func TestCheckUserDonLimitBeforeDeploy(t *testing.T) {

--- a/cmd/workflow/deploy/limits.go
+++ b/cmd/workflow/deploy/limits.go
@@ -11,6 +11,7 @@ import (
 
 const (
 	workflowStatusActive = uint8(0)
+	workflowStatusPaused = uint8(1)
 	workflowListPageSize = int64(200)
 )
 


### PR DESCRIPTION
[DEVSVCS-3603](https://smartcontract-it.atlassian.net/browse/DEVSVCS-3603)

This pull request introduces a warning mechanism to notify users when a paused workflow has been updated during deployment.

**Warning and status handling improvements:**

* Added a new function `warnIfPausedWorkflowUpdate` in `deploy.go` that outputs a warning if the workflow being updated is currently paused. This ensures users are informed about updates to paused workflows.
* Introduced the `workflowStatusPaused` constant to represent the paused state of a workflow.
