### PR TITLE
Add workflow exist check to centralized registry workflow deploy

### DIFF
--- a/cmd/workflow/deploy/deploy.go
+++ b/cmd/workflow/deploy/deploy.go
@@ -240,10 +240,16 @@ func (h *handler) Execute(ctx context.Context) error {
 		return err
 	}
 
-	exists, err := adapter.CheckWorkflowExists()
+	exists, existingStatus, err := adapter.CheckWorkflowExists(
+		h.inputs.WorkflowOwner,
+		h.inputs.WorkflowName,
+		h.inputs.WorkflowTag,
+		h.workflowArtifact.WorkflowID,
+	)
 	if err != nil {
 		return fmt.Errorf("failed to check if workflow exists: %w", err)
 	}
+	h.existingWorkflowStatus = existingStatus
 	if exists {
 		if err := confirmWorkflowOverwrite(h.inputs.WorkflowName, h.inputs.SkipConfirmation); err != nil {
 			return err

--- a/cmd/workflow/deploy/deploy.go
+++ b/cmd/workflow/deploy/deploy.go
@@ -240,6 +240,16 @@ func (h *handler) Execute(ctx context.Context) error {
 		return err
 	}
 
+	exists, err := adapter.CheckWorkflowExists()
+	if err != nil {
+		return fmt.Errorf("failed to check if workflow exists: %w", err)
+	}
+	if exists {
+		if err := confirmWorkflowOverwrite(h.inputs.WorkflowName, h.inputs.SkipConfirmation); err != nil {
+			return err
+		}
+	}
+
 	ui.Line()
 	ui.Dim("Uploading files...")
 	if err := h.uploadArtifacts(); err != nil {

--- a/cmd/workflow/deploy/deploy.go
+++ b/cmd/workflow/deploy/deploy.go
@@ -343,3 +343,20 @@ func (h *handler) displayWorkflowDetails() {
 	ui.Dim(fmt.Sprintf("Owner Address: %s", h.inputs.WorkflowOwner))
 	ui.Line()
 }
+
+func confirmWorkflowOverwrite(workflowName string, skipConfirmation bool) error {
+	ui.Warning(fmt.Sprintf("Workflow %s already exists", workflowName))
+	ui.Dim("This will update the existing workflow.")
+
+	if !skipConfirmation {
+		confirm, err := ui.Confirm("Are you sure you want to overwrite the workflow?")
+		if err != nil {
+			return err
+		}
+		if !confirm {
+			return errors.New("deployment cancelled by user")
+		}
+	}
+
+	return nil
+}

--- a/cmd/workflow/deploy/deploy_test.go
+++ b/cmd/workflow/deploy/deploy_test.go
@@ -782,14 +782,6 @@ type deployMockGraphQLRequest struct {
 	Variables map[string]interface{} `json:"variables"`
 }
 
-func newMockGQLServer(t *testing.T, response map[string]any) *httptest.Server {
-	t.Helper()
-	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(response)
-	}))
-}
-
 func newAssertGQLServer(
 	t *testing.T,
 	handler func(t *testing.T, req deployMockGraphQLRequest) (status int, response map[string]any),

--- a/cmd/workflow/deploy/deploy_test.go
+++ b/cmd/workflow/deploy/deploy_test.go
@@ -9,6 +9,7 @@ import (
 	"math/big"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -572,33 +573,45 @@ func TestExecute_PrivateRegistry(t *testing.T) {
 		defer wasmServer.Close()
 
 		gqlServer := newAssertGQLServer(t, func(t *testing.T, req deployMockGraphQLRequest) (int, map[string]any) {
-			assert.Contains(t, req.Query, "mutation UpsertOffchainWorkflow")
-			rawRequest, ok := req.Variables["request"].(map[string]any)
-			require.True(t, ok)
-			rawWorkflow, ok := rawRequest["workflow"].(map[string]any)
-			require.True(t, ok)
-			assert.Equal(t, "test_workflow", rawWorkflow["workflowName"])
-			assert.Equal(t, "test-don", rawWorkflow["donFamily"])
-			assert.Equal(t, wasmServer.URL+"/binary.wasm", rawWorkflow["binaryUrl"])
-			assert.Equal(t, "WORKFLOW_STATUS_ACTIVE", rawWorkflow["status"])
+			switch {
+			case req.Query != "" && containsQuery(req.Query, "query GetOffchainWorkflowByName"):
+				rawRequest, ok := req.Variables["request"].(map[string]any)
+				require.True(t, ok)
+				assert.Equal(t, "test_workflow", rawRequest["workflowName"])
+				return http.StatusOK, map[string]any{
+					"errors": []map[string]string{{"message": "workflow not found"}},
+				}
+			case req.Query != "" && containsQuery(req.Query, "mutation UpsertOffchainWorkflow"):
+				rawRequest, ok := req.Variables["request"].(map[string]any)
+				require.True(t, ok)
+				rawWorkflow, ok := rawRequest["workflow"].(map[string]any)
+				require.True(t, ok)
+				assert.Equal(t, "test_workflow", rawWorkflow["workflowName"])
+				assert.Equal(t, "test-don", rawWorkflow["donFamily"])
+				assert.Equal(t, wasmServer.URL+"/binary.wasm", rawWorkflow["binaryUrl"])
+				assert.Equal(t, "WORKFLOW_STATUS_ACTIVE", rawWorkflow["status"])
 
-			return http.StatusOK, map[string]any{
-				"data": map[string]any{
-					"upsertOffchainWorkflow": map[string]any{
-						"workflow": map[string]any{
-							"workflowId":   "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
-							"owner":        chainsim.TestAddress,
-							"createdAt":    "2025-01-01T00:00:00Z",
-							"status":       "WORKFLOW_STATUS_ACTIVE",
-							"workflowName": "test_workflow",
-							"binaryUrl":    wasmServer.URL + "/binary.wasm",
-							"configUrl":    "",
-							"tag":          "test_workflow",
-							"attributes":   "",
-							"donFamily":    "test-don",
+				return http.StatusOK, map[string]any{
+					"data": map[string]any{
+						"upsertOffchainWorkflow": map[string]any{
+							"workflow": map[string]any{
+								"workflowId":   "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+								"owner":        chainsim.TestAddress,
+								"createdAt":    "2025-01-01T00:00:00Z",
+								"status":       "WORKFLOW_STATUS_ACTIVE",
+								"workflowName": "test_workflow",
+								"binaryUrl":    wasmServer.URL + "/binary.wasm",
+								"configUrl":    "",
+								"tag":          "test_workflow",
+								"attributes":   "",
+								"donFamily":    "test-don",
+							},
 						},
 					},
-				},
+				}
+			default:
+				t.Fatalf("unexpected GraphQL operation: %s", req.Query)
+				return 0, nil
 			}
 		})
 		defer gqlServer.Close()
@@ -609,14 +622,125 @@ func TestExecute_PrivateRegistry(t *testing.T) {
 		assert.NotEmpty(t, h.workflowArtifact.WorkflowID)
 	})
 
-	t.Run("surfaces GraphQL errors from private execute path", func(t *testing.T) {
+	t.Run("continues when private workflow lookup returns not found", func(t *testing.T) {
 		wasmServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			_, _ = w.Write([]byte("workflow wasm payload"))
 		}))
 		defer wasmServer.Close()
 
-		gqlServer := newMockGQLServer(t, map[string]any{
-			"errors": []map[string]string{{"message": "unauthorized"}},
+		gqlServer := newAssertGQLServer(t, func(t *testing.T, req deployMockGraphQLRequest) (int, map[string]any) {
+			if containsQuery(req.Query, "query GetOffchainWorkflowByName") {
+				return http.StatusOK, map[string]any{
+					"errors": []map[string]string{{"message": "workflow not found"}},
+				}
+			}
+			if containsQuery(req.Query, "mutation UpsertOffchainWorkflow") {
+				return http.StatusOK, map[string]any{
+					"data": map[string]any{
+						"upsertOffchainWorkflow": map[string]any{
+							"workflow": map[string]any{
+								"workflowId":   "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+								"owner":        chainsim.TestAddress,
+								"createdAt":    "2025-01-01T00:00:00Z",
+								"status":       "WORKFLOW_STATUS_ACTIVE",
+								"workflowName": "test_workflow",
+								"binaryUrl":    wasmServer.URL + "/binary.wasm",
+								"configUrl":    "",
+								"tag":          "test_workflow",
+								"attributes":   "",
+								"donFamily":    "test-don",
+							},
+						},
+					},
+				}
+			}
+			t.Fatalf("unexpected GraphQL operation: %s", req.Query)
+			return 0, nil
+		})
+		defer gqlServer.Close()
+
+		h := newPrivateRegistryExecuteHandler(t, wasmServer.URL+"/binary.wasm", gqlServer.URL)
+		require.NoError(t, h.ValidateInputs())
+		require.NoError(t, h.Execute(context.Background()))
+	})
+
+	t.Run("prompts overwrite path can proceed with skip confirmation", func(t *testing.T) {
+		wasmServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte("workflow wasm payload"))
+		}))
+		defer wasmServer.Close()
+
+		gqlServer := newAssertGQLServer(t, func(t *testing.T, req deployMockGraphQLRequest) (int, map[string]any) {
+			if containsQuery(req.Query, "query GetOffchainWorkflowByName") {
+				return http.StatusOK, map[string]any{
+					"data": map[string]any{
+						"getOffchainWorkflowByName": map[string]any{
+							"workflow": map[string]any{
+								"workflowId":   "existing-wf-id",
+								"owner":        chainsim.TestAddress,
+								"createdAt":    "2025-01-01T00:00:00Z",
+								"status":       "WORKFLOW_STATUS_ACTIVE",
+								"workflowName": "test_workflow",
+								"binaryUrl":    "https://example.com/old.wasm",
+								"configUrl":    "",
+								"tag":          "test_workflow",
+								"attributes":   "",
+								"donFamily":    "test-don",
+							},
+						},
+					},
+				}
+			}
+			if containsQuery(req.Query, "mutation UpsertOffchainWorkflow") {
+				return http.StatusOK, map[string]any{
+					"data": map[string]any{
+						"upsertOffchainWorkflow": map[string]any{
+							"workflow": map[string]any{
+								"workflowId":   "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+								"owner":        chainsim.TestAddress,
+								"createdAt":    "2025-01-01T00:00:00Z",
+								"status":       "WORKFLOW_STATUS_ACTIVE",
+								"workflowName": "test_workflow",
+								"binaryUrl":    wasmServer.URL + "/binary.wasm",
+								"configUrl":    "",
+								"tag":          "test_workflow",
+								"attributes":   "",
+								"donFamily":    "test-don",
+							},
+						},
+					},
+				}
+			}
+			t.Fatalf("unexpected GraphQL operation: %s", req.Query)
+			return 0, nil
+		})
+		defer gqlServer.Close()
+
+		h := newPrivateRegistryExecuteHandler(t, wasmServer.URL+"/binary.wasm", gqlServer.URL)
+		h.inputs.SkipConfirmation = true
+		require.NoError(t, h.ValidateInputs())
+		require.NoError(t, h.Execute(context.Background()))
+	})
+
+	t.Run("surfaces GraphQL errors from private execute upsert path", func(t *testing.T) {
+		wasmServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte("workflow wasm payload"))
+		}))
+		defer wasmServer.Close()
+
+		gqlServer := newAssertGQLServer(t, func(t *testing.T, req deployMockGraphQLRequest) (int, map[string]any) {
+			if containsQuery(req.Query, "query GetOffchainWorkflowByName") {
+				return http.StatusOK, map[string]any{
+					"errors": []map[string]string{{"message": "workflow not found"}},
+				}
+			}
+			if containsQuery(req.Query, "mutation UpsertOffchainWorkflow") {
+				return http.StatusOK, map[string]any{
+					"errors": []map[string]string{{"message": "unauthorized"}},
+				}
+			}
+			t.Fatalf("unexpected GraphQL operation: %s", req.Query)
+			return 0, nil
 		})
 		defer gqlServer.Close()
 
@@ -628,22 +752,28 @@ func TestExecute_PrivateRegistry(t *testing.T) {
 		assert.Contains(t, err.Error(), "unauthorized")
 	})
 
-	t.Run("surfaces transport errors from private execute path", func(t *testing.T) {
+	t.Run("surfaces transport errors from private existence check", func(t *testing.T) {
 		wasmServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			_, _ = w.Write([]byte("workflow wasm payload"))
 		}))
 		defer wasmServer.Close()
 
-		gqlServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-			http.Error(w, "server exploded", http.StatusInternalServerError)
-		}))
+		gqlServer := newAssertGQLServer(t, func(t *testing.T, req deployMockGraphQLRequest) (int, map[string]any) {
+			if containsQuery(req.Query, "query GetOffchainWorkflowByName") {
+				return http.StatusInternalServerError, map[string]any{
+					"errors": []map[string]string{{"message": "server exploded"}},
+				}
+			}
+			t.Fatalf("unexpected GraphQL operation: %s", req.Query)
+			return 0, nil
+		})
 		defer gqlServer.Close()
 
 		h := newPrivateRegistryExecuteHandler(t, wasmServer.URL+"/binary.wasm", gqlServer.URL)
 		require.NoError(t, h.ValidateInputs())
 		err := h.Execute(context.Background())
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "failed to register workflow in private registry")
+		assert.Contains(t, err.Error(), "failed to check if workflow exists")
 	})
 }
 
@@ -676,6 +806,10 @@ func newAssertGQLServer(
 			_ = json.NewEncoder(w).Encode(response)
 		}
 	}))
+}
+
+func containsQuery(query, operation string) bool {
+	return query != "" && strings.Contains(query, operation)
 }
 
 func newPrivateRegistryExecuteHandler(t *testing.T, wasmURL, gqlURL string) *handler {

--- a/cmd/workflow/deploy/deploy_test.go
+++ b/cmd/workflow/deploy/deploy_test.go
@@ -572,7 +572,7 @@ func TestExecute_PrivateRegistry(t *testing.T) {
 		defer wasmServer.Close()
 
 		gqlServer := newAssertGQLServer(t, func(t *testing.T, req deployMockGraphQLRequest) (int, map[string]any) {
-			assert.Contains(t, req.Query, "mutation UpsertWorkflowInRegistry")
+			assert.Contains(t, req.Query, "mutation UpsertOffchainWorkflow")
 			rawRequest, ok := req.Variables["request"].(map[string]any)
 			require.True(t, ok)
 			rawWorkflow, ok := rawRequest["workflow"].(map[string]any)
@@ -584,7 +584,7 @@ func TestExecute_PrivateRegistry(t *testing.T) {
 
 			return http.StatusOK, map[string]any{
 				"data": map[string]any{
-					"upsertWorkflowInRegistry": map[string]any{
+					"upsertOffchainWorkflow": map[string]any{
 						"workflow": map[string]any{
 							"workflowId":   "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
 							"owner":        chainsim.TestAddress,

--- a/cmd/workflow/deploy/private_registry_test.go
+++ b/cmd/workflow/deploy/private_registry_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
+	"net/http"
 	"os"
 	"testing"
 
@@ -173,6 +174,132 @@ func TestResolveInputs_PreviewPrivateRegistryFlag(t *testing.T) {
 	})
 }
 
+func TestCheckWorkflowExists_PrivateRegistry(t *testing.T) {
+	tests := []struct {
+		name         string
+		serverStatus int
+		response     map[string]any
+		wantExists   bool
+		wantStatus   *uint8
+		wantErr      bool
+	}{
+		{
+			name:         "found active workflow returns active status",
+			serverStatus: http.StatusOK,
+			response: map[string]any{
+				"data": map[string]any{
+					"getOffchainWorkflowByName": map[string]any{
+						"workflow": map[string]any{
+							"workflowId":     "00a2b96d2f06961c3e0cf6fbba5cfa30d3b577026de094e5202d5fc3e3aabb87",
+							"owner":          "6028e8bd8759240ffe7bd80bdd5c99ca662f3363",
+							"createdAt":      "2026-04-10T14:07:25Z",
+							"status":         "WORKFLOW_STATUS_ACTIVE",
+							"workflowName":   "jnowak-workflow-test-v5",
+							"binaryUrl":      "https://storage.cre.stage.external.griddle.sh/artifacts/00a2b96d2f06961c3e0cf6fbba5cfa30d3b577026de094e5202d5fc3e3aabb87/binary.wasm",
+							"configUrl":      "https://storage.cre.stage.external.griddle.sh/artifacts/00a2b96d2f06961c3e0cf6fbba5cfa30d3b577026de094e5202d5fc3e3aabb87/config",
+							"tag":            "",
+							"attributes":     "{\"app\": \"test\"}",
+							"donFamily":      "zone-a",
+							"organizationId": "org_meoybOR7KEkNhEFf",
+						},
+					},
+				},
+			},
+			wantExists: true,
+			wantStatus: uint8Ptr(0),
+			wantErr:    false,
+		},
+		{
+			name:         "found paused workflow returns paused status",
+			serverStatus: http.StatusOK,
+			response: map[string]any{
+				"data": map[string]any{
+					"getOffchainWorkflowByName": map[string]any{
+						"workflow": map[string]any{
+							"workflowId":     "00a2b96d2f06961c3e0cf6fbba5cfa30d3b577026de094e5202d5fc3e3aabb87",
+							"owner":          "6028e8bd8759240ffe7bd80bdd5c99ca662f3363",
+							"createdAt":      "2026-04-10T14:07:25Z",
+							"status":         "WORKFLOW_STATUS_PAUSED",
+							"workflowName":   "jnowak-workflow-test-v5",
+							"binaryUrl":      "https://storage.cre.stage.external.griddle.sh/artifacts/00a2b96d2f06961c3e0cf6fbba5cfa30d3b577026de094e5202d5fc3e3aabb87/binary.wasm",
+							"configUrl":      "https://storage.cre.stage.external.griddle.sh/artifacts/00a2b96d2f06961c3e0cf6fbba5cfa30d3b577026de094e5202d5fc3e3aabb87/config",
+							"tag":            "",
+							"attributes":     "{\"app\": \"test\"}",
+							"donFamily":      "zone-a",
+							"organizationId": "org_meoybOR7KEkNhEFf",
+						},
+					},
+				},
+			},
+			wantExists: true,
+			wantStatus: uint8Ptr(1),
+			wantErr:    false,
+		},
+		{
+			name:         "not found returns no error and no status",
+			serverStatus: http.StatusOK,
+			response: map[string]any{
+				"errors": []map[string]any{
+					{
+						"message": "workflow not found",
+						"path":    []string{"getOffchainWorkflowByName"},
+						"extensions": map[string]any{
+							"code": "NOT_FOUND",
+						},
+					},
+				},
+				"data": nil,
+			},
+			wantExists: false,
+			wantStatus: nil,
+			wantErr:    false,
+		},
+		{
+			name:         "transport failure returns error",
+			serverStatus: http.StatusInternalServerError,
+			response: map[string]any{
+				"errors": []map[string]any{
+					{
+						"message": "server exploded",
+					},
+				},
+			},
+			wantExists: false,
+			wantStatus: nil,
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			simulatedEnvironment := chainsim.NewSimulatedEnvironment(t)
+			defer simulatedEnvironment.Close()
+
+			ctx, buf := simulatedEnvironment.NewRuntimeContextWithBufferedOutput()
+			h := newHandler(ctx, buf)
+			h.credentials = makeAPIKeyCredentials(t)
+
+			gqlServer := newAssertGQLServer(t, func(t *testing.T, req deployMockGraphQLRequest) (int, map[string]any) {
+				require.True(t, containsQuery(req.Query, "query GetOffchainWorkflowByName"))
+				return tt.serverStatus, tt.response
+			})
+			defer gqlServer.Close()
+
+			h.environmentSet.GraphQLURL = gqlServer.URL
+			strategy := newPrivateRegistryDeployStrategy(h)
+
+			exists, status, err := strategy.CheckWorkflowExists("", "jnowak-workflow-test-v5", "", "")
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, tt.wantExists, exists)
+			assert.Equal(t, tt.wantStatus, status)
+		})
+	}
+}
+
 func makeTestJWT(t *testing.T, claims map[string]interface{}) string {
 	t.Helper()
 	header, _ := json.Marshal(map[string]string{"alg": "HS256", "typ": "JWT"})
@@ -212,6 +339,10 @@ func makeAPIKeyCredentials(t *testing.T) *credentials.Credentials {
 	creds.AuthType = credentials.AuthTypeApiKey
 	creds.APIKey = "test-key"
 	return creds
+}
+
+func uint8Ptr(v uint8) *uint8 {
+	return &v
 }
 
 func TestResolveWorkflowOwner(t *testing.T) {

--- a/cmd/workflow/deploy/registry_deploy_strategy.go
+++ b/cmd/workflow/deploy/registry_deploy_strategy.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/smartcontractkit/cre-cli/internal/environments"
-	"github.com/smartcontractkit/cre-cli/internal/ui"
 )
 
 // errDeployHalted is a sentinel returned by RunPreDeployChecks when the deploy
@@ -80,21 +79,4 @@ func newRegistryDeployStrategy(targetWorkflowRegistry registryTarget, h *handler
 		return newPrivateRegistryDeployStrategy(h)
 	}
 	return newOnchainRegistryDeployStrategy(h)
-}
-
-func confirmWorkflowOverwrite(workflowName string, skipConfirmation bool) error {
-	ui.Warning(fmt.Sprintf("Workflow %s already exists", workflowName))
-	ui.Dim("This will update the existing workflow.")
-
-	if !skipConfirmation {
-		confirm, err := ui.Confirm("Are you sure you want to overwrite the workflow?")
-		if err != nil {
-			return err
-		}
-		if !confirm {
-			return errors.New("deployment cancelled by user")
-		}
-	}
-
-	return nil
 }

--- a/cmd/workflow/deploy/registry_deploy_strategy.go
+++ b/cmd/workflow/deploy/registry_deploy_strategy.go
@@ -23,8 +23,8 @@ type registryDeployStrategy interface {
 	RunPreDeployChecks() error
 
 	// CheckWorkflowExists returns whether a same-name workflow exists for this
-	// registry target.
-	CheckWorkflowExists() (bool, error)
+	// registry target and includes the existing workflow status for updates.
+	CheckWorkflowExists(workflowOwner, workflowName, workflowTag, workflowID string) (bool, *uint8, error)
 
 	// Upsert registers or updates the workflow in the target registry
 	// and displays the result.

--- a/cmd/workflow/deploy/registry_deploy_strategy.go
+++ b/cmd/workflow/deploy/registry_deploy_strategy.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/smartcontractkit/cre-cli/internal/environments"
+	"github.com/smartcontractkit/cre-cli/internal/ui"
 )
 
 // errDeployHalted is a sentinel returned by RunPreDeployChecks when the deploy
@@ -21,6 +22,10 @@ type registryDeployStrategy interface {
 	// prechecks (ownership linking, duplicate detection, etc.).
 	// Return errDeployHalted to stop the deploy without returning an error.
 	RunPreDeployChecks() error
+
+	// CheckWorkflowExists returns whether a same-name workflow exists for this
+	// registry target.
+	CheckWorkflowExists() (bool, error)
 
 	// Upsert registers or updates the workflow in the target registry
 	// and displays the result.
@@ -75,4 +80,21 @@ func newRegistryDeployStrategy(targetWorkflowRegistry registryTarget, h *handler
 		return newPrivateRegistryDeployStrategy(h)
 	}
 	return newOnchainRegistryDeployStrategy(h)
+}
+
+func confirmWorkflowOverwrite(workflowName string, skipConfirmation bool) error {
+	ui.Warning(fmt.Sprintf("Workflow %s already exists", workflowName))
+	ui.Dim("This will update the existing workflow.")
+
+	if !skipConfirmation {
+		confirm, err := ui.Confirm("Are you sure you want to overwrite the workflow?")
+		if err != nil {
+			return err
+		}
+		if !confirm {
+			return errors.New("deployment cancelled by user")
+		}
+	}
+
+	return nil
 }

--- a/cmd/workflow/deploy/registry_deploy_strategy_onchain.go
+++ b/cmd/workflow/deploy/registry_deploy_strategy_onchain.go
@@ -1,7 +1,6 @@
 package deploy
 
 import (
-	"errors"
 	"fmt"
 	"sync"
 
@@ -59,26 +58,19 @@ func (a *onchainRegistryDeployStrategy) RunPreDeployChecks() error {
 		}
 	}
 
-	existsErr := h.workflowExists()
-	if existsErr != nil {
-		if existsErr.Error() == "workflow with name "+h.inputs.WorkflowName+" already exists" {
-			ui.Warning(fmt.Sprintf("Workflow %s already exists", h.inputs.WorkflowName))
-			ui.Dim("This will update the existing workflow.")
-			if !h.inputs.SkipConfirmation {
-				confirm, err := ui.Confirm("Are you sure you want to overwrite the workflow?")
-				if err != nil {
-					return err
-				}
-				if !confirm {
-					return errors.New("deployment cancelled by user")
-				}
-			}
-		} else {
-			return existsErr
-		}
+	return nil
+}
+
+func (a *onchainRegistryDeployStrategy) CheckWorkflowExists() (bool, error) {
+	existsErr := a.h.workflowExists()
+	if existsErr == nil {
+		return false, nil
+	}
+	if existsErr.Error() == "workflow with name "+a.h.inputs.WorkflowName+" already exists" {
+		return true, nil
 	}
 
-	return nil
+	return false, existsErr
 }
 
 func (a *onchainRegistryDeployStrategy) Upsert() error {

--- a/cmd/workflow/deploy/registry_deploy_strategy_onchain.go
+++ b/cmd/workflow/deploy/registry_deploy_strategy_onchain.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 
+	"github.com/smartcontractkit/cre-cli/cmd/client"
 	"github.com/smartcontractkit/cre-cli/internal/constants"
 	"github.com/smartcontractkit/cre-cli/internal/ui"
 )
@@ -15,6 +16,7 @@ import (
 // duplicate detection, and DON limit checks.
 type onchainRegistryDeployStrategy struct {
 	h       *handler
+	wrc     *client.WorkflowRegistryV2Client
 	wg      sync.WaitGroup
 	initErr error
 }
@@ -29,6 +31,7 @@ func newOnchainRegistryDeployStrategy(h *handler) *onchainRegistryDeployStrategy
 			a.initErr = fmt.Errorf("failed to create workflow registry client: %w", err)
 			return
 		}
+		a.wrc = wrc
 		h.wrc = wrc
 	}()
 	return a
@@ -61,24 +64,28 @@ func (a *onchainRegistryDeployStrategy) RunPreDeployChecks() error {
 	return nil
 }
 
-func (a *onchainRegistryDeployStrategy) CheckWorkflowExists() (bool, error) {
-	existsErr := a.h.workflowExists()
-	if existsErr == nil {
-		return false, nil
+func (a *onchainRegistryDeployStrategy) CheckWorkflowExists(workflowOwner, workflowName, workflowTag, workflowID string) (bool, *uint8, error) {
+	workflow, err := a.wrc.GetWorkflow(common.HexToAddress(workflowOwner), workflowName, workflowTag)
+	if err != nil {
+		return false, nil, err
 	}
-	if existsErr.Error() == "workflow with name "+a.h.inputs.WorkflowName+" already exists" {
-		return true, nil
+	if workflow.WorkflowId == [32]byte(common.Hex2Bytes(workflowID)) {
+		return false, nil, fmt.Errorf("workflow with id %s already exists", workflowID)
+	}
+	if workflow.WorkflowName == workflowName {
+		status := workflow.Status
+		return true, &status, nil
 	}
 
-	return false, existsErr
+	return false, nil, nil
 }
 
 func (a *onchainRegistryDeployStrategy) Upsert() error {
 	h := a.h
 
 	if err := checkUserDonLimitBeforeDeploy(
-		h.wrc,
-		h.wrc,
+		a.wrc,
+		a.wrc,
 		common.HexToAddress(h.inputs.WorkflowOwner),
 		h.inputs.DonFamily,
 		h.inputs.WorkflowName,
@@ -92,22 +99,6 @@ func (a *onchainRegistryDeployStrategy) Upsert() error {
 	ui.Dim("Preparing deployment transaction...")
 	if err := h.upsert(); err != nil {
 		return fmt.Errorf("failed to register workflow: %w", err)
-	}
-	return nil
-}
-
-func (h *handler) workflowExists() error {
-	workflow, err := h.wrc.GetWorkflow(common.HexToAddress(h.inputs.WorkflowOwner), h.inputs.WorkflowName, h.inputs.WorkflowTag)
-	if err != nil {
-		return err
-	}
-	if workflow.WorkflowId == [32]byte(common.Hex2Bytes(h.workflowArtifact.WorkflowID)) {
-		return fmt.Errorf("workflow with id %s already exists", h.workflowArtifact.WorkflowID)
-	}
-	if workflow.WorkflowName == h.inputs.WorkflowName {
-		status := workflow.Status
-		h.existingWorkflowStatus = &status
-		return fmt.Errorf("workflow with name %s already exists", h.inputs.WorkflowName)
 	}
 	return nil
 }

--- a/cmd/workflow/deploy/registry_deploy_strategy_private.go
+++ b/cmd/workflow/deploy/registry_deploy_strategy_private.go
@@ -31,18 +31,18 @@ func (a *privateRegistryDeployStrategy) RunPreDeployChecks() error {
 	return nil
 }
 
-func (a *privateRegistryDeployStrategy) CheckWorkflowExists() (bool, error) {
+func (a *privateRegistryDeployStrategy) CheckWorkflowExists(_, workflowName, _, _ string) (bool, *uint8, error) {
 	a.ensureClient()
 
-	_, err := a.prc.GetWorkflowByName(a.h.inputs.WorkflowName)
+	_, err := a.prc.GetWorkflowByName(workflowName)
 	if err == nil {
-		return true, nil
+		return true, nil, nil
 	}
 	if isWorkflowNotFoundError(err) {
-		return false, nil
+		return false, nil, nil
 	}
 
-	return false, err
+	return false, nil, err
 }
 
 func (a *privateRegistryDeployStrategy) Upsert() error {

--- a/cmd/workflow/deploy/registry_deploy_strategy_private.go
+++ b/cmd/workflow/deploy/registry_deploy_strategy_private.go
@@ -34,9 +34,9 @@ func (a *privateRegistryDeployStrategy) RunPreDeployChecks() error {
 func (a *privateRegistryDeployStrategy) CheckWorkflowExists(_, workflowName, _, _ string) (bool, *uint8, error) {
 	a.ensureClient()
 
-	_, err := a.prc.GetWorkflowByName(workflowName)
+	workflow, err := a.prc.GetWorkflowByName(workflowName)
 	if err == nil {
-		return true, nil, nil
+		return true, offchainStatusToUint8(workflow.Status), nil
 	}
 	if isWorkflowNotFoundError(err) {
 		return false, nil, nil
@@ -100,4 +100,17 @@ func (h *handler) buildPrivateRegistryInput() privateregistryclient.OffchainWork
 func isWorkflowNotFoundError(err error) bool {
 	msg := strings.ToLower(err.Error())
 	return strings.Contains(msg, "not found")
+}
+
+func offchainStatusToUint8(status privateregistryclient.OffchainWorkflowStatus) *uint8 {
+	switch status {
+	case privateregistryclient.WorkflowStatusActive:
+		v := uint8(0)
+		return &v
+	case privateregistryclient.WorkflowStatusPaused:
+		v := uint8(1)
+		return &v
+	default:
+		return nil
+	}
 }

--- a/cmd/workflow/deploy/registry_deploy_strategy_private.go
+++ b/cmd/workflow/deploy/registry_deploy_strategy_private.go
@@ -63,8 +63,8 @@ func (a *privateRegistryDeployStrategy) Upsert() error {
 	return nil
 }
 
-func (h *handler) buildPrivateRegistryInput() privateregistryclient.WorkflowInRegistryInput {
-	input := privateregistryclient.WorkflowInRegistryInput{
+func (h *handler) buildPrivateRegistryInput() privateregistryclient.OffchainWorkflowInput {
+	input := privateregistryclient.OffchainWorkflowInput{
 		WorkflowID:   h.workflowArtifact.WorkflowID,
 		Status:       privateregistryclient.WorkflowStatusActive,
 		WorkflowName: h.inputs.WorkflowName,

--- a/cmd/workflow/deploy/registry_deploy_strategy_private.go
+++ b/cmd/workflow/deploy/registry_deploy_strategy_private.go
@@ -2,6 +2,7 @@ package deploy
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/smartcontractkit/cre-cli/internal/client/graphqlclient"
 	"github.com/smartcontractkit/cre-cli/internal/client/privateregistryclient"
@@ -27,9 +28,21 @@ func (a *privateRegistryDeployStrategy) ensureClient() {
 }
 
 func (a *privateRegistryDeployStrategy) RunPreDeployChecks() error {
-
-	// TODO: check if workflow already exists in private registry and confirm update
 	return nil
+}
+
+func (a *privateRegistryDeployStrategy) CheckWorkflowExists() (bool, error) {
+	a.ensureClient()
+
+	_, err := a.prc.GetWorkflowByName(a.h.inputs.WorkflowName)
+	if err == nil {
+		return true, nil
+	}
+	if isWorkflowNotFoundError(err) {
+		return false, nil
+	}
+
+	return false, err
 }
 
 func (a *privateRegistryDeployStrategy) Upsert() error {
@@ -82,4 +95,9 @@ func (h *handler) buildPrivateRegistryInput() privateregistryclient.OffchainWork
 	}
 
 	return input
+}
+
+func isWorkflowNotFoundError(err error) bool {
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "not found")
 }

--- a/internal/client/privateregistryclient/privateregistryclient.go
+++ b/internal/client/privateregistryclient/privateregistryclient.go
@@ -106,6 +106,61 @@ type DeleteOffchainWorkflowResponse struct {
 	WorkflowID string `json:"workflowId"`
 }
 
+type GetOffchainWorkflowByNameRequest struct {
+	WorkflowName string `json:"workflowName"`
+}
+
+type GetOffchainWorkflowByNameResponse struct {
+	Workflow OffchainWorkflow `json:"workflow"`
+}
+
+func (c *Client) GetWorkflowByName(workflowName string) (OffchainWorkflow, error) {
+	if workflowName == "" {
+		return OffchainWorkflow{}, fmt.Errorf("workflowName is required")
+	}
+	if len(workflowName) > maxWorkflowNameLength {
+		return OffchainWorkflow{}, fmt.Errorf("workflowName exceeds max length %d", maxWorkflowNameLength)
+	}
+
+	const query = `
+query GetOffchainWorkflowByName($request: GetOffchainWorkflowByNameRequest!) {
+  getOffchainWorkflowByName(request: $request) {
+    workflow {
+      workflowId
+      owner
+      createdAt
+      status
+      workflowName
+      binaryUrl
+      configUrl
+      tag
+      attributes
+      donFamily
+      organizationId
+    }
+  }
+}`
+
+	req := graphql.NewRequest(query)
+	req.Var("request", GetOffchainWorkflowByNameRequest{WorkflowName: workflowName})
+
+	var container struct {
+		GetOffchainWorkflowByName GetOffchainWorkflowByNameResponse `json:"getOffchainWorkflowByName"`
+	}
+
+	ctx, cancel := c.CreateServiceContextWithTimeout()
+	defer cancel()
+
+	if err := c.graphql.Execute(ctx, req, &container); err != nil {
+		return OffchainWorkflow{}, fmt.Errorf("get workflow by name in registry: %w", err)
+	}
+
+	c.log.Debug().Str("workflowName", workflowName).
+		Msg("Fetched workflow by name from private registry")
+
+	return container.GetOffchainWorkflowByName.Workflow, nil
+}
+
 func (c *Client) UpsertWorkflowInRegistry(workflow OffchainWorkflowInput) (OffchainWorkflow, error) {
 	if err := validateUpsertWorkflowInput(workflow); err != nil {
 		return OffchainWorkflow{}, err

--- a/internal/client/privateregistryclient/privateregistryclient.go
+++ b/internal/client/privateregistryclient/privateregistryclient.go
@@ -34,17 +34,17 @@ func (c *Client) CreateServiceContextWithTimeout() (context.Context, context.Can
 }
 
 type OffchainWorkflow struct {
-	WorkflowID     string                   `json:"workflowId"`
-	Owner          string                   `json:"owner"`
-	CreatedAt      string                   `json:"createdAt"`
-	Status         OffchainWorkflowStatus   `json:"status"`
-	WorkflowName   string                   `json:"workflowName"`
-	BinaryURL      string                   `json:"binaryUrl"`
-	ConfigURL      string                   `json:"configUrl"`
-	Tag            string                   `json:"tag"`
-	Attributes     string                   `json:"attributes"`
-	DonFamily      string                   `json:"donFamily"`
-	OrganizationID string                   `json:"organizationId"`
+	WorkflowID     string                 `json:"workflowId"`
+	Owner          string                 `json:"owner"`
+	CreatedAt      string                 `json:"createdAt"`
+	Status         OffchainWorkflowStatus `json:"status"`
+	WorkflowName   string                 `json:"workflowName"`
+	BinaryURL      string                 `json:"binaryUrl"`
+	ConfigURL      string                 `json:"configUrl"`
+	Tag            string                 `json:"tag"`
+	Attributes     string                 `json:"attributes"`
+	DonFamily      string                 `json:"donFamily"`
+	OrganizationID string                 `json:"organizationId"`
 }
 
 type OffchainWorkflowStatus string
@@ -64,14 +64,14 @@ const (
 )
 
 type OffchainWorkflowInput struct {
-	WorkflowID   string                   `json:"workflowId"`
-	Status       OffchainWorkflowStatus   `json:"status"`
-	WorkflowName string                   `json:"workflowName"`
-	BinaryURL    string                   `json:"binaryUrl"`
-	ConfigURL    *string                  `json:"configUrl,omitempty"`
-	Tag          *string                  `json:"tag,omitempty"`
-	Attributes   *string                  `json:"attributes,omitempty"`
-	DonFamily    string                   `json:"donFamily"`
+	WorkflowID   string                 `json:"workflowId"`
+	Status       OffchainWorkflowStatus `json:"status"`
+	WorkflowName string                 `json:"workflowName"`
+	BinaryURL    string                 `json:"binaryUrl"`
+	ConfigURL    *string                `json:"configUrl,omitempty"`
+	Tag          *string                `json:"tag,omitempty"`
+	Attributes   *string                `json:"attributes,omitempty"`
+	DonFamily    string                 `json:"donFamily"`
 }
 
 type UpsertOffchainWorkflowRequest struct {

--- a/internal/client/privateregistryclient/privateregistryclient.go
+++ b/internal/client/privateregistryclient/privateregistryclient.go
@@ -33,11 +33,11 @@ func (c *Client) CreateServiceContextWithTimeout() (context.Context, context.Can
 	return context.WithTimeout(context.Background(), c.serviceTimeout) //nolint:gosec // G118 -- cancel is deferred by callers
 }
 
-type WorkflowInRegistry struct {
+type OffchainWorkflow struct {
 	WorkflowID     string                   `json:"workflowId"`
 	Owner          string                   `json:"owner"`
 	CreatedAt      string                   `json:"createdAt"`
-	Status         WorkflowInRegistryStatus `json:"status"`
+	Status         OffchainWorkflowStatus   `json:"status"`
 	WorkflowName   string                   `json:"workflowName"`
 	BinaryURL      string                   `json:"binaryUrl"`
 	ConfigURL      string                   `json:"configUrl"`
@@ -47,12 +47,12 @@ type WorkflowInRegistry struct {
 	OrganizationID string                   `json:"organizationId"`
 }
 
-type WorkflowInRegistryStatus string
+type OffchainWorkflowStatus string
 
 const (
-	WorkflowStatusUnspecified WorkflowInRegistryStatus = "WORKFLOW_STATUS_UNSPECIFIED"
-	WorkflowStatusActive      WorkflowInRegistryStatus = "WORKFLOW_STATUS_ACTIVE"
-	WorkflowStatusPaused      WorkflowInRegistryStatus = "WORKFLOW_STATUS_PAUSED"
+	WorkflowStatusUnspecified OffchainWorkflowStatus = "WORKFLOW_STATUS_UNSPECIFIED"
+	WorkflowStatusActive      OffchainWorkflowStatus = "WORKFLOW_STATUS_ACTIVE"
+	WorkflowStatusPaused      OffchainWorkflowStatus = "WORKFLOW_STATUS_PAUSED"
 )
 
 const (
@@ -63,9 +63,9 @@ const (
 	maxAttributesLength   = 1024
 )
 
-type WorkflowInRegistryInput struct {
+type OffchainWorkflowInput struct {
 	WorkflowID   string                   `json:"workflowId"`
-	Status       WorkflowInRegistryStatus `json:"status"`
+	Status       OffchainWorkflowStatus   `json:"status"`
 	WorkflowName string                   `json:"workflowName"`
 	BinaryURL    string                   `json:"binaryUrl"`
 	ConfigURL    *string                  `json:"configUrl,omitempty"`
@@ -74,46 +74,46 @@ type WorkflowInRegistryInput struct {
 	DonFamily    string                   `json:"donFamily"`
 }
 
-type UpsertWorkflowInRegistryRequest struct {
-	Workflow WorkflowInRegistryInput `json:"workflow"`
+type UpsertOffchainWorkflowRequest struct {
+	Workflow OffchainWorkflowInput `json:"workflow"`
 }
 
-type UpsertWorkflowInRegistryResponse struct {
-	Workflow WorkflowInRegistry `json:"workflow"`
+type UpsertOffchainWorkflowResponse struct {
+	Workflow OffchainWorkflow `json:"workflow"`
 }
 
-type PauseWorkflowInRegistryRequest struct {
+type PauseOffchainWorkflowRequest struct {
 	WorkflowID string `json:"workflowId"`
 }
 
-type PauseWorkflowInRegistryResponse struct {
-	Workflow WorkflowInRegistry `json:"workflow"`
+type PauseOffchainWorkflowResponse struct {
+	Workflow OffchainWorkflow `json:"workflow"`
 }
 
-type ActivateWorkflowInRegistryRequest struct {
+type ActivateOffchainWorkflowRequest struct {
 	WorkflowID string `json:"workflowId"`
 }
 
-type ActivateWorkflowInRegistryResponse struct {
-	Workflow WorkflowInRegistry `json:"workflow"`
+type ActivateOffchainWorkflowResponse struct {
+	Workflow OffchainWorkflow `json:"workflow"`
 }
 
-type DeleteWorkflowInRegistryRequest struct {
+type DeleteOffchainWorkflowRequest struct {
 	WorkflowID string `json:"workflowId"`
 }
 
-type DeleteWorkflowInRegistryResponse struct {
+type DeleteOffchainWorkflowResponse struct {
 	WorkflowID string `json:"workflowId"`
 }
 
-func (c *Client) UpsertWorkflowInRegistry(workflow WorkflowInRegistryInput) (WorkflowInRegistry, error) {
+func (c *Client) UpsertWorkflowInRegistry(workflow OffchainWorkflowInput) (OffchainWorkflow, error) {
 	if err := validateUpsertWorkflowInput(workflow); err != nil {
-		return WorkflowInRegistry{}, err
+		return OffchainWorkflow{}, err
 	}
 
 	const mutation = `
-mutation UpsertWorkflowInRegistry($request: UpsertWorkflowInRegistryRequest!) {
-  upsertWorkflowInRegistry(request: $request) {
+mutation UpsertOffchainWorkflow($request: UpsertOffchainWorkflowRequest!) {
+  upsertOffchainWorkflow(request: $request) {
     workflow {
       workflowId
       owner
@@ -131,33 +131,33 @@ mutation UpsertWorkflowInRegistry($request: UpsertWorkflowInRegistryRequest!) {
 }`
 
 	req := graphql.NewRequest(mutation)
-	req.Var("request", UpsertWorkflowInRegistryRequest{Workflow: workflow})
+	req.Var("request", UpsertOffchainWorkflowRequest{Workflow: workflow})
 
 	var container struct {
-		UpsertWorkflowInRegistry UpsertWorkflowInRegistryResponse `json:"upsertWorkflowInRegistry"`
+		UpsertOffchainWorkflow UpsertOffchainWorkflowResponse `json:"upsertOffchainWorkflow"`
 	}
 
 	ctx, cancel := c.CreateServiceContextWithTimeout()
 	defer cancel()
 
 	if err := c.graphql.Execute(ctx, req, &container); err != nil {
-		return WorkflowInRegistry{}, fmt.Errorf("upsert workflow in registry: %w", err)
+		return OffchainWorkflow{}, fmt.Errorf("upsert workflow in registry: %w", err)
 	}
 
-	c.log.Debug().Str("workflowId", container.UpsertWorkflowInRegistry.Workflow.WorkflowID).
+	c.log.Debug().Str("workflowId", container.UpsertOffchainWorkflow.Workflow.WorkflowID).
 		Msg("Upserted workflow in private registry")
 
-	return container.UpsertWorkflowInRegistry.Workflow, nil
+	return container.UpsertOffchainWorkflow.Workflow, nil
 }
 
-func (c *Client) PauseWorkflowInRegistry(workflowID string) (WorkflowInRegistry, error) {
+func (c *Client) PauseWorkflowInRegistry(workflowID string) (OffchainWorkflow, error) {
 	if workflowID == "" {
-		return WorkflowInRegistry{}, fmt.Errorf("workflowId is required")
+		return OffchainWorkflow{}, fmt.Errorf("workflowId is required")
 	}
 
 	const mutation = `
-mutation PauseWorkflowInRegistry($request: PauseWorkflowInRegistryRequest!) {
-  pauseWorkflowInRegistry(request: $request) {
+mutation PauseOffchainWorkflow($request: PauseOffchainWorkflowRequest!) {
+  pauseOffchainWorkflow(request: $request) {
     workflow {
       workflowId
       owner
@@ -175,33 +175,33 @@ mutation PauseWorkflowInRegistry($request: PauseWorkflowInRegistryRequest!) {
 }`
 
 	req := graphql.NewRequest(mutation)
-	req.Var("request", PauseWorkflowInRegistryRequest{WorkflowID: workflowID})
+	req.Var("request", PauseOffchainWorkflowRequest{WorkflowID: workflowID})
 
 	var container struct {
-		PauseWorkflowInRegistry PauseWorkflowInRegistryResponse `json:"pauseWorkflowInRegistry"`
+		PauseOffchainWorkflow PauseOffchainWorkflowResponse `json:"pauseOffchainWorkflow"`
 	}
 
 	ctx, cancel := c.CreateServiceContextWithTimeout()
 	defer cancel()
 
 	if err := c.graphql.Execute(ctx, req, &container); err != nil {
-		return WorkflowInRegistry{}, fmt.Errorf("pause workflow in registry: %w", err)
+		return OffchainWorkflow{}, fmt.Errorf("pause workflow in registry: %w", err)
 	}
 
 	c.log.Debug().Str("workflowId", workflowID).
 		Msg("Paused workflow in private registry")
 
-	return container.PauseWorkflowInRegistry.Workflow, nil
+	return container.PauseOffchainWorkflow.Workflow, nil
 }
 
-func (c *Client) ActivateWorkflowInRegistry(workflowID string) (WorkflowInRegistry, error) {
+func (c *Client) ActivateWorkflowInRegistry(workflowID string) (OffchainWorkflow, error) {
 	if workflowID == "" {
-		return WorkflowInRegistry{}, fmt.Errorf("workflowId is required")
+		return OffchainWorkflow{}, fmt.Errorf("workflowId is required")
 	}
 
 	const mutation = `
-mutation ActivateWorkflowInRegistry($request: ActivateWorkflowInRegistryRequest!) {
-  activateWorkflowInRegistry(request: $request) {
+mutation ActivateOffchainWorkflow($request: ActivateOffchainWorkflowRequest!) {
+  activateOffchainWorkflow(request: $request) {
     workflow {
       workflowId
       owner
@@ -219,23 +219,23 @@ mutation ActivateWorkflowInRegistry($request: ActivateWorkflowInRegistryRequest!
 }`
 
 	req := graphql.NewRequest(mutation)
-	req.Var("request", ActivateWorkflowInRegistryRequest{WorkflowID: workflowID})
+	req.Var("request", ActivateOffchainWorkflowRequest{WorkflowID: workflowID})
 
 	var container struct {
-		ActivateWorkflowInRegistry ActivateWorkflowInRegistryResponse `json:"activateWorkflowInRegistry"`
+		ActivateOffchainWorkflow ActivateOffchainWorkflowResponse `json:"activateOffchainWorkflow"`
 	}
 
 	ctx, cancel := c.CreateServiceContextWithTimeout()
 	defer cancel()
 
 	if err := c.graphql.Execute(ctx, req, &container); err != nil {
-		return WorkflowInRegistry{}, fmt.Errorf("activate workflow in registry: %w", err)
+		return OffchainWorkflow{}, fmt.Errorf("activate workflow in registry: %w", err)
 	}
 
 	c.log.Debug().Str("workflowId", workflowID).
 		Msg("Activated workflow in private registry")
 
-	return container.ActivateWorkflowInRegistry.Workflow, nil
+	return container.ActivateOffchainWorkflow.Workflow, nil
 }
 
 func (c *Client) DeleteWorkflowInRegistry(workflowID string) (string, error) {
@@ -244,17 +244,17 @@ func (c *Client) DeleteWorkflowInRegistry(workflowID string) (string, error) {
 	}
 
 	const mutation = `
-mutation DeleteWorkflowInRegistry($request: DeleteWorkflowInRegistryRequest!) {
-  deleteWorkflowInRegistry(request: $request) {
+mutation DeleteOffchainWorkflow($request: DeleteOffchainWorkflowRequest!) {
+  deleteOffchainWorkflow(request: $request) {
     workflowId
   }
 }`
 
 	req := graphql.NewRequest(mutation)
-	req.Var("request", DeleteWorkflowInRegistryRequest{WorkflowID: workflowID})
+	req.Var("request", DeleteOffchainWorkflowRequest{WorkflowID: workflowID})
 
 	var container struct {
-		DeleteWorkflowInRegistry DeleteWorkflowInRegistryResponse `json:"deleteWorkflowInRegistry"`
+		DeleteOffchainWorkflow DeleteOffchainWorkflowResponse `json:"deleteOffchainWorkflow"`
 	}
 
 	ctx, cancel := c.CreateServiceContextWithTimeout()
@@ -267,10 +267,10 @@ mutation DeleteWorkflowInRegistry($request: DeleteWorkflowInRegistryRequest!) {
 	c.log.Debug().Str("workflowId", workflowID).
 		Msg("Deleted workflow in private registry")
 
-	return container.DeleteWorkflowInRegistry.WorkflowID, nil
+	return container.DeleteOffchainWorkflow.WorkflowID, nil
 }
 
-func validateUpsertWorkflowInput(input WorkflowInRegistryInput) error {
+func validateUpsertWorkflowInput(input OffchainWorkflowInput) error {
 	if input.WorkflowID == "" {
 		return fmt.Errorf("workflowId is required")
 	}

--- a/internal/client/privateregistryclient/privateregistryclient_test.go
+++ b/internal/client/privateregistryclient/privateregistryclient_test.go
@@ -20,7 +20,7 @@ import (
 
 func TestValidateUpsertWorkflowInput(t *testing.T) {
 	t.Run("valid input", func(t *testing.T) {
-		err := validateUpsertWorkflowInput(WorkflowInRegistryInput{
+		err := validateUpsertWorkflowInput(OffchainWorkflowInput{
 			WorkflowID:   "wf-1",
 			Status:       WorkflowStatusActive,
 			WorkflowName: "test-workflow",
@@ -32,47 +32,47 @@ func TestValidateUpsertWorkflowInput(t *testing.T) {
 
 	tests := []struct {
 		name  string
-		input WorkflowInRegistryInput
+		input OffchainWorkflowInput
 		err   string
 	}{
 		{
 			name:  "missing workflowId",
-			input: WorkflowInRegistryInput{Status: WorkflowStatusActive, WorkflowName: "w", BinaryURL: "b", DonFamily: "f"},
+			input: OffchainWorkflowInput{Status: WorkflowStatusActive, WorkflowName: "w", BinaryURL: "b", DonFamily: "f"},
 			err:   "workflowId is required",
 		},
 		{
 			name:  "missing status",
-			input: WorkflowInRegistryInput{WorkflowID: "wf", WorkflowName: "w", BinaryURL: "b", DonFamily: "f"},
+			input: OffchainWorkflowInput{WorkflowID: "wf", WorkflowName: "w", BinaryURL: "b", DonFamily: "f"},
 			err:   "status is required",
 		},
 		{
 			name:  "missing workflowName",
-			input: WorkflowInRegistryInput{WorkflowID: "wf", Status: WorkflowStatusActive, BinaryURL: "b", DonFamily: "f"},
+			input: OffchainWorkflowInput{WorkflowID: "wf", Status: WorkflowStatusActive, BinaryURL: "b", DonFamily: "f"},
 			err:   "workflowName is required",
 		},
 		{
 			name:  "missing binaryUrl",
-			input: WorkflowInRegistryInput{WorkflowID: "wf", Status: WorkflowStatusActive, WorkflowName: "w", DonFamily: "f"},
+			input: OffchainWorkflowInput{WorkflowID: "wf", Status: WorkflowStatusActive, WorkflowName: "w", DonFamily: "f"},
 			err:   "binaryUrl is required",
 		},
 		{
 			name:  "missing donFamily",
-			input: WorkflowInRegistryInput{WorkflowID: "wf", Status: WorkflowStatusActive, WorkflowName: "w", BinaryURL: "b"},
+			input: OffchainWorkflowInput{WorkflowID: "wf", Status: WorkflowStatusActive, WorkflowName: "w", BinaryURL: "b"},
 			err:   "donFamily is required",
 		},
 		{
 			name:  "invalid status",
-			input: WorkflowInRegistryInput{WorkflowID: "wf", Status: "INVALID", WorkflowName: "w", BinaryURL: "b", DonFamily: "f"},
+			input: OffchainWorkflowInput{WorkflowID: "wf", Status: "INVALID", WorkflowName: "w", BinaryURL: "b", DonFamily: "f"},
 			err:   "status must be one of \"WORKFLOW_STATUS_UNSPECIFIED\", \"WORKFLOW_STATUS_ACTIVE\", \"WORKFLOW_STATUS_PAUSED\"",
 		},
 		{
 			name:  "workflowName exceeds max length",
-			input: WorkflowInRegistryInput{WorkflowID: "wf", Status: WorkflowStatusActive, WorkflowName: strings.Repeat("a", maxWorkflowNameLength+1), BinaryURL: "b", DonFamily: "f"},
+			input: OffchainWorkflowInput{WorkflowID: "wf", Status: WorkflowStatusActive, WorkflowName: strings.Repeat("a", maxWorkflowNameLength+1), BinaryURL: "b", DonFamily: "f"},
 			err:   "workflowName exceeds max length 64",
 		},
 		{
 			name:  "binaryUrl exceeds max length",
-			input: WorkflowInRegistryInput{WorkflowID: "wf", Status: WorkflowStatusActive, WorkflowName: "w", BinaryURL: strings.Repeat("b", maxBinaryURLLength+1), DonFamily: "f"},
+			input: OffchainWorkflowInput{WorkflowID: "wf", Status: WorkflowStatusActive, WorkflowName: "w", BinaryURL: strings.Repeat("b", maxBinaryURLLength+1), DonFamily: "f"},
 			err:   "binaryUrl exceeds max length 200",
 		},
 	}
@@ -101,7 +101,7 @@ func TestUpsertWorkflowInRegistry(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"data": map[string]any{
-				"upsertWorkflowInRegistry": map[string]any{
+				"upsertOffchainWorkflow": map[string]any{
 					"workflow": map[string]any{
 						"workflowId":     "wf-123",
 						"owner":          "owner-1",
@@ -125,7 +125,7 @@ func TestUpsertWorkflowInRegistry(t *testing.T) {
 	configURL := "s3://config"
 	tag := "v1"
 	attributes := "{\"region\":\"us-east-1\"}"
-	result, err := client.UpsertWorkflowInRegistry(WorkflowInRegistryInput{
+	result, err := client.UpsertWorkflowInRegistry(OffchainWorkflowInput{
 		WorkflowID:   "wf-123",
 		Status:       WorkflowStatusActive,
 		WorkflowName: "registry-workflow",
@@ -137,8 +137,8 @@ func TestUpsertWorkflowInRegistry(t *testing.T) {
 	})
 
 	require.NoError(t, err)
-	assert.Contains(t, capturedQuery, "mutation UpsertWorkflowInRegistry")
-	assert.Contains(t, capturedQuery, "upsertWorkflowInRegistry")
+	assert.Contains(t, capturedQuery, "mutation UpsertOffchainWorkflow")
+	assert.Contains(t, capturedQuery, "upsertOffchainWorkflow")
 	assert.Equal(t, "wf-123", result.WorkflowID)
 	assert.Equal(t, WorkflowStatusActive, result.Status)
 	assert.Equal(t, "family-a", result.DonFamily)
@@ -165,7 +165,7 @@ func TestUpsertWorkflowInRegistry_GQLError(t *testing.T) {
 	defer srv.Close()
 
 	client := newTestPrivateRegistryClient(t, srv.URL)
-	_, err := client.UpsertWorkflowInRegistry(WorkflowInRegistryInput{
+	_, err := client.UpsertWorkflowInRegistry(OffchainWorkflowInput{
 		WorkflowID:   "wf-123",
 		Status:       WorkflowStatusActive,
 		WorkflowName: "registry-workflow",
@@ -189,7 +189,7 @@ func TestPauseWorkflowInRegistry(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"data": map[string]any{
-				"pauseWorkflowInRegistry": map[string]any{
+				"pauseOffchainWorkflow": map[string]any{
 					"workflow": map[string]any{
 						"workflowId":     "wf-123",
 						"status":         "WORKFLOW_STATUS_PAUSED",
@@ -227,7 +227,7 @@ func TestActivateWorkflowInRegistry(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"data": map[string]any{
-				"activateWorkflowInRegistry": map[string]any{
+				"activateOffchainWorkflow": map[string]any{
 					"workflow": map[string]any{
 						"workflowId":     "wf-123",
 						"status":         "WORKFLOW_STATUS_ACTIVE",
@@ -264,7 +264,7 @@ func TestDeleteWorkflowInRegistry(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"data": map[string]any{
-				"deleteWorkflowInRegistry": map[string]any{
+				"deleteOffchainWorkflow": map[string]any{
 					"workflowId": "wf-123",
 				},
 			},

--- a/internal/client/privateregistryclient/privateregistryclient_test.go
+++ b/internal/client/privateregistryclient/privateregistryclient_test.go
@@ -176,6 +176,81 @@ func TestUpsertWorkflowInRegistry_GQLError(t *testing.T) {
 	assert.Contains(t, err.Error(), "upsert workflow in registry")
 }
 
+func TestGetWorkflowByName(t *testing.T) {
+	var capturedQuery string
+	var capturedVariables map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Query     string                 `json:"query"`
+			Variables map[string]interface{} `json:"variables"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		capturedQuery = req.Query
+		capturedVariables = req.Variables
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": map[string]any{
+				"getOffchainWorkflowByName": map[string]any{
+					"workflow": map[string]any{
+						"workflowId":     "wf-123",
+						"owner":          "owner-1",
+						"createdAt":      "2026-01-01T00:00:00Z",
+						"status":         "WORKFLOW_STATUS_ACTIVE",
+						"workflowName":   "registry-workflow",
+						"binaryUrl":      "s3://binary",
+						"configUrl":      "s3://config",
+						"tag":            "v1",
+						"attributes":     "{\"region\":\"us-east-1\"}",
+						"donFamily":      "family-a",
+						"organizationId": "org-1",
+					},
+				},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	client := newTestPrivateRegistryClient(t, srv.URL)
+	result, err := client.GetWorkflowByName("registry-workflow")
+
+	require.NoError(t, err)
+	assert.Contains(t, capturedQuery, "query GetOffchainWorkflowByName")
+	assert.Contains(t, capturedQuery, "getOffchainWorkflowByName")
+	assert.Equal(t, "wf-123", result.WorkflowID)
+	assert.Equal(t, WorkflowStatusActive, result.Status)
+	assert.Equal(t, "registry-workflow", result.WorkflowName)
+	assert.Equal(t, "family-a", result.DonFamily)
+	assert.Equal(t, "org-1", result.OrganizationID)
+
+	request, ok := capturedVariables["request"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "registry-workflow", request["workflowName"])
+}
+
+func TestGetWorkflowByName_GQLError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"errors": []map[string]string{{"message": "workflow not found"}},
+		})
+	}))
+	defer srv.Close()
+
+	client := newTestPrivateRegistryClient(t, srv.URL)
+	_, err := client.GetWorkflowByName("registry-workflow")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "get workflow by name in registry")
+}
+
+func TestGetWorkflowByName_EmptyName(t *testing.T) {
+	logger := testutil.NewTestLogger()
+	client := New(nil, logger)
+
+	_, err := client.GetWorkflowByName("")
+	require.EqualError(t, err, "workflowName is required")
+}
+
 func TestPauseWorkflowInRegistry(t *testing.T) {
 	var capturedVariables map[string]any
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/test/multi_command_flows/workflow_private_registry.go
+++ b/test/multi_command_flows/workflow_private_registry.go
@@ -147,6 +147,22 @@ func workflowDeployPrivateRegistry(t *testing.T, tc TestConfig) string {
 				return
 			}
 
+			if strings.Contains(req.Query, "GetOffchainWorkflowByName") {
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"errors": []map[string]any{
+						{
+							"message": "workflow not found",
+							"path":    []string{"getOffchainWorkflowByName"},
+							"extensions": map[string]any{
+								"code": "NOT_FOUND",
+							},
+						},
+					},
+					"data": nil,
+				})
+				return
+			}
+
 			if strings.Contains(req.Query, "UpsertOffchainWorkflow") {
 				upsertCalled.Store(true)
 				_ = json.NewEncoder(w).Encode(map[string]any{

--- a/test/multi_command_flows/workflow_private_registry.go
+++ b/test/multi_command_flows/workflow_private_registry.go
@@ -147,11 +147,11 @@ func workflowDeployPrivateRegistry(t *testing.T, tc TestConfig) string {
 				return
 			}
 
-			if strings.Contains(req.Query, "UpsertWorkflowInRegistry") {
+			if strings.Contains(req.Query, "UpsertOffchainWorkflow") {
 				upsertCalled.Store(true)
 				_ = json.NewEncoder(w).Encode(map[string]any{
 					"data": map[string]any{
-						"upsertWorkflowInRegistry": map[string]any{
+						"upsertOffchainWorkflow": map[string]any{
 							"workflow": map[string]any{
 								"workflowId":     "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
 								"owner":          privateRegistryOwnerAddress,
@@ -240,7 +240,7 @@ func workflowDeployPrivateRegistry(t *testing.T, tc TestConfig) string {
 	)
 	require.True(t, presignedPostCalled.Load(), "expected GeneratePresignedPostUrlForArtifact to be called")
 	require.True(t, uploadCalled.Load(), "expected artifact upload endpoint to be called")
-	require.True(t, upsertCalled.Load(), "expected UpsertWorkflowInRegistry to be called")
+	require.True(t, upsertCalled.Load(), "expected UpsertOffchainWorkflow to be called")
 
 	return StripANSI(stdout.String() + stderr.String())
 }


### PR DESCRIPTION
## Summary
- Adds a pre-deploy workflow existence check so `workflow deploy` can detect existing workflows before upload and prompt for overwrite confirmation.
- Implements private-registry existence checks via GraphQL lookup by workflow name, and threads the existing workflow status through deploy flow.
- Refactors registry deploy strategies to share a `CheckWorkflowExists` path across onchain and private targets.
- Updates private-registry client models/operations to the offchain workflow API naming and adds coverage for success, not-found, and transport-error paths.

## Testing
- Extended deploy and private-registry unit tests around existence checks, overwrite behavior, and GraphQL failure handling.
- Updated multi-command private-registry flow test to validate the new lookup + upsert operation sequence.