### PR TITLE
Replace getOrganization with getCreOrganizationInfo in auth validation

### DIFF
--- a/cmd/secrets/common/browser_flow.go
+++ b/cmd/secrets/common/browser_flow.go
@@ -66,9 +66,9 @@ func (h *Handler) executeBrowserUpsert(ctx context.Context, inputs UpsertSecrets
 	if h.Credentials.AuthType == credentials.AuthTypeApiKey {
 		return fmt.Errorf("this sign-in flow requires an interactive login; API keys are not supported")
 	}
-	orgID, err := h.Credentials.GetOrgID()
-	if err != nil {
-		return fmt.Errorf("organization information is missing from your session; sign in again or use owner-key-signing: %w", err)
+	orgID := h.Credentials.OrgID
+	if orgID == "" {
+		return fmt.Errorf("organization information is missing from your session; sign in again or use owner-key-signing")
 	}
 
 	ui.Dim("Using your account to authorize vault access for your organization...")

--- a/cmd/workflow/deploy/deploy.go
+++ b/cmd/workflow/deploy/deploy.go
@@ -2,7 +2,6 @@ package deploy
 
 import (
 	"context"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -10,8 +9,6 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-
-	workflowUtils "github.com/smartcontractkit/chainlink-common/pkg/workflows"
 
 	"github.com/smartcontractkit/cre-cli/cmd/client"
 	cmdcommon "github.com/smartcontractkit/cre-cli/cmd/common"
@@ -322,33 +319,23 @@ func (h *handler) prepareArtifacts() error {
 }
 
 // resolveWorkflowOwner returns the effective owner address for workflow ID computation.
-// For private registry deploys, the owner is derived from tenantID and organizationID.
+// For private registry deploys, the derived workflow owner from the runtime context is used.
 // For onchain deploys, the configured WorkflowOwner address is used directly.
 func (h *handler) resolveWorkflowOwner(targetWorkflowRegistry registryTarget) (string, error) {
 	if !targetWorkflowRegistry.isPrivate() {
 		return h.settings.Workflow.UserWorkflowSettings.WorkflowOwnerAddress, nil
 	}
 
-	if h.runtimeContext.TenantContext == nil {
-		return "", fmt.Errorf("tenant context is required for private registry deployment")
+	owner := h.runtimeContext.DerivedWorkflowOwner
+	if owner == "" {
+		return "", fmt.Errorf("derived workflow owner is not available; ensure authentication succeeded")
 	}
 
-	tenantID := h.runtimeContext.TenantContext.TenantID
-	if tenantID == "" {
-		return "", fmt.Errorf("tenant ID is required for private registry deployment")
+	if len(owner) >= 2 && owner[:2] != "0x" {
+		owner = "0x" + owner
 	}
 
-	orgID, err := h.credentials.GetOrgID()
-	if err != nil {
-		return "", fmt.Errorf("failed to get organization ID for private registry deployment: %w", err)
-	}
-
-	ownerBytes, err := workflowUtils.GenerateWorkflowOwnerAddress(tenantID, orgID)
-	if err != nil {
-		return "", fmt.Errorf("failed to derive workflow owner address: %w", err)
-	}
-
-	return "0x" + hex.EncodeToString(ownerBytes), nil
+	return owner, nil
 }
 
 func (h *handler) displayWorkflowDetails() {

--- a/cmd/workflow/deploy/deploy_test.go
+++ b/cmd/workflow/deploy/deploy_test.go
@@ -442,6 +442,10 @@ func TestResolveInputs_PrivateRegistryTarget(t *testing.T) {
 		simulatedEnvironment := chainsim.NewSimulatedEnvironment(t)
 		defer simulatedEnvironment.Close()
 
+		expectedBytes, err := workflowUtils.GenerateWorkflowOwnerAddress("42", "org-test-123")
+		require.NoError(t, err)
+		expectedOwner := "0x" + hex.EncodeToString(expectedBytes)
+
 		ctx, buf := simulatedEnvironment.NewRuntimeContextWithBufferedOutput()
 		h := newHandler(ctx, buf)
 		ctx.Settings = createTestSettings(
@@ -454,11 +458,7 @@ func TestResolveInputs_PrivateRegistryTarget(t *testing.T) {
 		h.settings = ctx.Settings
 		h.environmentSet.EnvName = "STAGING"
 		h.environmentSet.DonFamily = "test_label"
-		token := makeTestJWT(t, map[string]interface{}{
-			"sub":    "user1",
-			"org_id": "org-test-123",
-		})
-		h.credentials = makeBearerCredentials(t, token)
+		h.runtimeContext.DerivedWorkflowOwner = expectedOwner
 		h.runtimeContext.TenantContext = &tenantctx.EnvironmentContext{TenantID: "42"}
 		ctx.Viper.Set("preview-private-registry", true)
 
@@ -466,9 +466,7 @@ func TestResolveInputs_PrivateRegistryTarget(t *testing.T) {
 		require.NoError(t, err)
 		assert.True(t, inputs.PreviewPrivateRegistry)
 		assert.Equal(t, settings.RegistryTypeOffChain, inputs.TargetWorkflowRegistry.targetType)
-		expectedBytes, err := workflowUtils.GenerateWorkflowOwnerAddress("42", "org-test-123")
-		require.NoError(t, err)
-		assert.Equal(t, "0x"+hex.EncodeToString(expectedBytes), inputs.WorkflowOwner)
+		assert.Equal(t, expectedOwner, inputs.WorkflowOwner)
 	})
 
 	t.Run("rejects private target outside STAGING", func(t *testing.T) {
@@ -511,11 +509,7 @@ func TestValidateInputs_PrivateRegistry(t *testing.T) {
 		h.settings = ctx.Settings
 		h.environmentSet.EnvName = "STAGING"
 		h.environmentSet.DonFamily = "test_label"
-		token := makeTestJWT(t, map[string]interface{}{
-			"sub":    "user1",
-			"org_id": "org-test-123",
-		})
-		h.credentials = makeBearerCredentials(t, token)
+		h.runtimeContext.DerivedWorkflowOwner = "0xabcdef1234567890abcdef1234567890abcdef12"
 		h.runtimeContext.TenantContext = &tenantctx.EnvironmentContext{TenantID: "42"}
 		ctx.Viper.Set("preview-private-registry", true)
 		ctx.Viper.Set("wasm", "https://example.com/workflow.wasm")
@@ -547,11 +541,7 @@ func TestValidateInputs_PrivateRegistry(t *testing.T) {
 		h.environmentSet.EnvName = "STAGING"
 		h.environmentSet.DonFamily = ""
 		h.runtimeContext.ResolvedRegistry = settings.NewOffChainRegistry("private", "")
-		token := makeTestJWT(t, map[string]interface{}{
-			"sub":    "user1",
-			"org_id": "org-test-123",
-		})
-		h.credentials = makeBearerCredentials(t, token)
+		h.runtimeContext.DerivedWorkflowOwner = "0xabcdef1234567890abcdef1234567890abcdef12"
 		h.runtimeContext.TenantContext = &tenantctx.EnvironmentContext{TenantID: "42"}
 		ctx.Viper.Set("preview-private-registry", true)
 		ctx.Viper.Set("wasm", "https://example.com/workflow.wasm")

--- a/cmd/workflow/deploy/private_registry_test.go
+++ b/cmd/workflow/deploy/private_registry_test.go
@@ -370,40 +370,13 @@ func TestResolveWorkflowOwner(t *testing.T) {
 		assert.Equal(t, chainsim.TestAddress, owner)
 	})
 
-	t.Run("private target derives owner from tenantID and orgID", func(t *testing.T) {
+	t.Run("private target uses derived workflow owner from runtime context", func(t *testing.T) {
 		t.Parallel()
-
-		token := makeTestJWT(t, map[string]interface{}{
-			"sub":    "user1",
-			"org_id": "org-test-123",
-		})
-
-		simulatedEnvironment := chainsim.NewSimulatedEnvironment(t)
-		defer simulatedEnvironment.Close()
-
-		ctx, buf := simulatedEnvironment.NewRuntimeContextWithBufferedOutput()
-		h := newHandler(ctx, buf)
-		ctx.Settings = createTestSettings(
-			chainsim.TestAddress,
-			"eoa",
-			"test_workflow",
-			"testdata/basic_workflow/main.go",
-			"",
-		)
-		h.settings = ctx.Settings
-		h.credentials = makeBearerCredentials(t, token)
-		h.runtimeContext.TenantContext = &tenantctx.EnvironmentContext{TenantID: "42"}
-
-		owner, err := h.resolveWorkflowOwner(registryTarget{targetType: settings.RegistryTypeOffChain})
-		require.NoError(t, err)
 
 		expectedBytes, err := workflowUtils.GenerateWorkflowOwnerAddress("42", "org-test-123")
 		require.NoError(t, err)
-		assert.Equal(t, "0x"+hex.EncodeToString(expectedBytes), owner)
-	})
+		expectedOwner := "0x" + hex.EncodeToString(expectedBytes)
 
-	t.Run("private target errors when tenant context is nil", func(t *testing.T) {
-		t.Parallel()
 		simulatedEnvironment := chainsim.NewSimulatedEnvironment(t)
 		defer simulatedEnvironment.Close()
 
@@ -417,36 +390,14 @@ func TestResolveWorkflowOwner(t *testing.T) {
 			"",
 		)
 		h.settings = ctx.Settings
-		h.runtimeContext.TenantContext = nil
+		h.runtimeContext.DerivedWorkflowOwner = expectedOwner
 
-		_, err := h.resolveWorkflowOwner(registryTarget{targetType: settings.RegistryTypeOffChain})
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "tenant context is required")
+		owner, err := h.resolveWorkflowOwner(registryTarget{targetType: settings.RegistryTypeOffChain})
+		require.NoError(t, err)
+		assert.Equal(t, expectedOwner, owner)
 	})
 
-	t.Run("private target errors when tenant ID is empty", func(t *testing.T) {
-		t.Parallel()
-		simulatedEnvironment := chainsim.NewSimulatedEnvironment(t)
-		defer simulatedEnvironment.Close()
-
-		ctx, buf := simulatedEnvironment.NewRuntimeContextWithBufferedOutput()
-		h := newHandler(ctx, buf)
-		ctx.Settings = createTestSettings(
-			chainsim.TestAddress,
-			"eoa",
-			"test_workflow",
-			"testdata/basic_workflow/main.go",
-			"",
-		)
-		h.settings = ctx.Settings
-		h.runtimeContext.TenantContext = &tenantctx.EnvironmentContext{TenantID: ""}
-
-		_, err := h.resolveWorkflowOwner(registryTarget{targetType: settings.RegistryTypeOffChain})
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "tenant ID is required")
-	})
-
-	t.Run("private target errors when orgID unavailable", func(t *testing.T) {
+	t.Run("private target adds 0x prefix when missing", func(t *testing.T) {
 		t.Parallel()
 
 		simulatedEnvironment := chainsim.NewSimulatedEnvironment(t)
@@ -462,11 +413,32 @@ func TestResolveWorkflowOwner(t *testing.T) {
 			"",
 		)
 		h.settings = ctx.Settings
-		h.credentials = makeAPIKeyCredentials(t)
-		h.runtimeContext.TenantContext = &tenantctx.EnvironmentContext{TenantID: "42"}
+		h.runtimeContext.DerivedWorkflowOwner = "abcdef1234567890"
+
+		owner, err := h.resolveWorkflowOwner(registryTarget{targetType: settings.RegistryTypeOffChain})
+		require.NoError(t, err)
+		assert.Equal(t, "0xabcdef1234567890", owner)
+	})
+
+	t.Run("private target errors when derived workflow owner is empty", func(t *testing.T) {
+		t.Parallel()
+		simulatedEnvironment := chainsim.NewSimulatedEnvironment(t)
+		defer simulatedEnvironment.Close()
+
+		ctx, buf := simulatedEnvironment.NewRuntimeContextWithBufferedOutput()
+		h := newHandler(ctx, buf)
+		ctx.Settings = createTestSettings(
+			chainsim.TestAddress,
+			"eoa",
+			"test_workflow",
+			"testdata/basic_workflow/main.go",
+			"",
+		)
+		h.settings = ctx.Settings
+		h.runtimeContext.DerivedWorkflowOwner = ""
 
 		_, err := h.resolveWorkflowOwner(registryTarget{targetType: settings.RegistryTypeOffChain})
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "failed to get organization ID")
+		assert.Contains(t, err.Error(), "derived workflow owner is not available")
 	})
 }

--- a/cmd/workflow/deploy/private_registry_test.go
+++ b/cmd/workflow/deploy/private_registry_test.go
@@ -167,6 +167,7 @@ func TestResolveInputs_PreviewPrivateRegistryFlag(t *testing.T) {
 		})
 		h.credentials = makeBearerCredentials(t, token)
 		h.runtimeContext.TenantContext = &tenantctx.EnvironmentContext{TenantID: "42"}
+		h.runtimeContext.DerivedWorkflowOwner = "ab12cd34ef56ab12cd34ef56ab12cd34ef56ab12"
 		ctx.Viper.Set("preview-private-registry", true)
 
 		inputs, err := h.ResolveInputs(ctx.Viper)

--- a/internal/authvalidation/validator.go
+++ b/internal/authvalidation/validator.go
@@ -12,12 +12,19 @@ import (
 	"github.com/smartcontractkit/cre-cli/internal/environments"
 )
 
-const queryOrganization = `
-query GetOrganizationDetails  {
-	getOrganization {
-		organizationId
+const queryCreOrganizationInfo = `
+query GetCreOrganizationInfo {
+	getCreOrganizationInfo {
+		orgId
+		derivedWorkflowOwners
 	}
 }`
+
+// ValidationResult holds the data returned by credential validation.
+type ValidationResult struct {
+	OrgID                string
+	DerivedWorkflowOwner string
+}
 
 // Validator validates authentication credentials
 type Validator struct {
@@ -35,32 +42,42 @@ func NewValidator(creds *credentials.Credentials, environmentSet *environments.E
 }
 
 // ValidateCredentials validates the provided credentials by making a lightweight GraphQL query
-// The GraphQL client automatically handles token refresh if needed
-func (v *Validator) ValidateCredentials(validationCtx context.Context, creds *credentials.Credentials) error {
+// and returns organization info including the derived workflow owner.
+// The GraphQL client automatically handles token refresh if needed.
+func (v *Validator) ValidateCredentials(validationCtx context.Context, creds *credentials.Credentials) (*ValidationResult, error) {
 	if creds == nil {
-		return fmt.Errorf("credentials not provided")
+		return nil, fmt.Errorf("credentials not provided")
 	}
 
-	// Skip validation if already validated
 	if creds.IsValidated {
-		return nil
+		return nil, nil
 	}
 
-	req := graphql.NewRequest(queryOrganization)
+	req := graphql.NewRequest(queryCreOrganizationInfo)
 
 	var respEnvelope struct {
-		GetOrganization struct {
-			OrganizationID string `json:"organizationId"`
-		} `json:"getOrganization"`
+		GetCreOrganizationInfo struct {
+			OrgID                 string   `json:"orgId"`
+			DerivedWorkflowOwners []string `json:"derivedWorkflowOwners"`
+		} `json:"getCreOrganizationInfo"`
 	}
 
 	if err := v.gqlClient.Execute(validationCtx, req, &respEnvelope); err != nil {
-		return fmt.Errorf("authentication validation failed: %w", err)
+		return nil, fmt.Errorf("authentication failed: unable to retrieve organization info. Your account may not be fully set up yet — please try again in a few minutes: %w", err)
 	}
 
-	if orgID := respEnvelope.GetOrganization.OrganizationID; orgID != "" {
-		creds.OrgID = orgID
+	info := respEnvelope.GetCreOrganizationInfo
+
+	if info.OrgID == "" || len(info.DerivedWorkflowOwners) == 0 {
+		return nil, fmt.Errorf("authentication failed: unable to retrieve organization info. Your account may not be fully set up yet — please try again in a few minutes")
 	}
 
-	return nil
+	result := &ValidationResult{
+		OrgID:                info.OrgID,
+		DerivedWorkflowOwner: info.DerivedWorkflowOwners[0],
+	}
+
+	creds.OrgID = result.OrgID
+
+	return result, nil
 }

--- a/internal/runtime/runtime_context.go
+++ b/internal/runtime/runtime_context.go
@@ -32,6 +32,9 @@ type Context struct {
 	TenantContext    *tenantctx.EnvironmentContext
 	ResolvedRegistry settings.ResolvedRegistry
 	Workflow         WorkflowRuntime
+
+	OrgID                string
+	DerivedWorkflowOwner string
 }
 
 type WorkflowRuntime struct {
@@ -79,8 +82,14 @@ func (ctx *Context) AttachCredentials(validationCtx context.Context, skipValidat
 		}
 
 		validator := authvalidation.NewValidator(ctx.Credentials, ctx.EnvironmentSet, ctx.Logger)
-		if err := validator.ValidateCredentials(validationCtx, ctx.Credentials); err != nil {
+		result, err := validator.ValidateCredentials(validationCtx, ctx.Credentials)
+		if err != nil {
 			return fmt.Errorf("%w: %w", ErrValidationFailed, err)
+		}
+
+		if result != nil {
+			ctx.OrgID = result.OrgID
+			ctx.DerivedWorkflowOwner = result.DerivedWorkflowOwner
 		}
 	}
 

--- a/internal/testutil/graphql_mock.go
+++ b/internal/testutil/graphql_mock.go
@@ -11,8 +11,8 @@ import (
 )
 
 // NewGraphQLMockServerGetOrganization starts an httptest.Server that responds to
-// getOrganization with a fixed organizationId. It sets EnvVarGraphQLURL so CLI
-// commands use this server. Caller must defer srv.Close().
+// getCreOrganizationInfo with a fixed orgId and derivedWorkflowOwners.
+// It sets EnvVarGraphQLURL so CLI commands use this server. Caller must defer srv.Close().
 func NewGraphQLMockServerGetOrganization(t *testing.T) *httptest.Server {
 	t.Helper()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -23,10 +23,13 @@ func NewGraphQLMockServerGetOrganization(t *testing.T) *httptest.Server {
 			}
 			_ = json.NewDecoder(r.Body).Decode(&req)
 			w.Header().Set("Content-Type", "application/json")
-			if strings.Contains(req.Query, "getOrganization") {
+			if strings.Contains(req.Query, "getCreOrganizationInfo") {
 				_ = json.NewEncoder(w).Encode(map[string]any{
 					"data": map[string]any{
-						"getOrganization": map[string]any{"organizationId": "test-org-id"},
+						"getCreOrganizationInfo": map[string]any{
+							"orgId":                 "test-org-id",
+							"derivedWorkflowOwners": []string{"ab12cd34ef56ab12cd34ef56ab12cd34ef56ab12"},
+						},
 					},
 				})
 				return

--- a/test/graphql_mock.go
+++ b/test/graphql_mock.go
@@ -8,7 +8,7 @@ import (
 )
 
 // NewGraphQLMockServerGetOrganization starts a mock GraphQL server that responds to
-// getOrganization and sets EnvVarGraphQLURL. Caller must defer srv.Close().
+// getCreOrganizationInfo and sets EnvVarGraphQLURL. Caller must defer srv.Close().
 func NewGraphQLMockServerGetOrganization(t *testing.T) *httptest.Server {
 	return testutil.NewGraphQLMockServerGetOrganization(t)
 }

--- a/test/multi_command_flows/account_happy_path.go
+++ b/test/multi_command_flows/account_happy_path.go
@@ -57,11 +57,12 @@ func RunAccountHappyPath(t *testing.T, tc TestConfig, testEthURL, chainName stri
 		w.Header().Set("Content-Type", "application/json")
 
 		// Handle authentication validation query
-		if strings.Contains(req.Query, "getOrganization") {
+		if strings.Contains(req.Query, "getCreOrganizationInfo") {
 			_ = json.NewEncoder(w).Encode(map[string]any{
 				"data": map[string]any{
-					"getOrganization": map[string]any{
-						"organizationId": "test-org-id",
+					"getCreOrganizationInfo": map[string]any{
+						"orgId":                 "test-org-id",
+						"derivedWorkflowOwners": []string{"ab12cd34ef56ab12cd34ef56ab12cd34ef56ab12"},
 					},
 				},
 			})

--- a/test/multi_command_flows/secrets_happy_path.go
+++ b/test/multi_command_flows/secrets_happy_path.go
@@ -62,11 +62,12 @@ func RunSecretsHappyPath(t *testing.T, tc TestConfig, chainName string) {
 			w.Header().Set("Content-Type", "application/json")
 
 			// Handle authentication validation query
-			if strings.Contains(req.Query, "getOrganization") {
+			if strings.Contains(req.Query, "getCreOrganizationInfo") {
 				_ = json.NewEncoder(w).Encode(map[string]any{
 					"data": map[string]any{
-						"getOrganization": map[string]any{
-							"organizationId": "test-org-id",
+						"getCreOrganizationInfo": map[string]any{
+							"orgId":                 "test-org-id",
+							"derivedWorkflowOwners": []string{"ab12cd34ef56ab12cd34ef56ab12cd34ef56ab12"},
 						},
 					},
 				})
@@ -256,11 +257,12 @@ func RunSecretsListMsig(t *testing.T, tc TestConfig, chainName string) {
 			w.Header().Set("Content-Type", "application/json")
 
 			// Handle authentication validation query
-			if strings.Contains(req.Query, "getOrganization") {
+			if strings.Contains(req.Query, "getCreOrganizationInfo") {
 				_ = json.NewEncoder(w).Encode(map[string]any{
 					"data": map[string]any{
-						"getOrganization": map[string]any{
-							"organizationId": "test-org-id",
+						"getCreOrganizationInfo": map[string]any{
+							"orgId":                 "test-org-id",
+							"derivedWorkflowOwners": []string{"ab12cd34ef56ab12cd34ef56ab12cd34ef56ab12"},
 						},
 					},
 				})

--- a/test/multi_command_flows/workflow_happy_path_1.go
+++ b/test/multi_command_flows/workflow_happy_path_1.go
@@ -61,11 +61,12 @@ func workflowDeployEoaWithMockStorage(t *testing.T, tc TestConfig) (output strin
 			w.Header().Set("Content-Type", "application/json")
 
 			// Handle authentication validation query
-			if strings.Contains(req.Query, "getOrganization") {
+			if strings.Contains(req.Query, "getCreOrganizationInfo") {
 				_ = json.NewEncoder(w).Encode(map[string]any{
 					"data": map[string]any{
-						"getOrganization": map[string]any{
-							"organizationId": "test-org-id",
+						"getCreOrganizationInfo": map[string]any{
+							"orgId":                 "test-org-id",
+							"derivedWorkflowOwners": []string{"ab12cd34ef56ab12cd34ef56ab12cd34ef56ab12"},
 						},
 					},
 				})

--- a/test/multi_command_flows/workflow_happy_path_2.go
+++ b/test/multi_command_flows/workflow_happy_path_2.go
@@ -34,11 +34,12 @@ func workflowDeployEoa(t *testing.T, tc TestConfig) string {
 			w.Header().Set("Content-Type", "application/json")
 
 			// Handle authentication validation query
-			if strings.Contains(req.Query, "getOrganization") {
+			if strings.Contains(req.Query, "getCreOrganizationInfo") {
 				_ = json.NewEncoder(w).Encode(map[string]any{
 					"data": map[string]any{
-						"getOrganization": map[string]any{
-							"organizationId": "test-org-id",
+						"getCreOrganizationInfo": map[string]any{
+							"orgId":                 "test-org-id",
+							"derivedWorkflowOwners": []string{"ab12cd34ef56ab12cd34ef56ab12cd34ef56ab12"},
 						},
 					},
 				})
@@ -154,11 +155,12 @@ func workflowDeployUpdateWithConfig(t *testing.T, tc TestConfig) string {
 			w.Header().Set("Content-Type", "application/json")
 
 			// Handle authentication validation query
-			if strings.Contains(req.Query, "getOrganization") {
+			if strings.Contains(req.Query, "getCreOrganizationInfo") {
 				_ = json.NewEncoder(w).Encode(map[string]any{
 					"data": map[string]any{
-						"getOrganization": map[string]any{
-							"organizationId": "test-org-id",
+						"getCreOrganizationInfo": map[string]any{
+							"orgId":                 "test-org-id",
+							"derivedWorkflowOwners": []string{"ab12cd34ef56ab12cd34ef56ab12cd34ef56ab12"},
 						},
 					},
 				})

--- a/test/multi_command_flows/workflow_happy_path_3.go
+++ b/test/multi_command_flows/workflow_happy_path_3.go
@@ -31,11 +31,12 @@ func workflowInit(t *testing.T, projectRootFlag, projectName, workflowName strin
 			w.Header().Set("Content-Type", "application/json")
 
 			// Handle authentication validation query
-			if strings.Contains(req.Query, "getOrganization") {
+			if strings.Contains(req.Query, "getCreOrganizationInfo") {
 				_ = json.NewEncoder(w).Encode(map[string]any{
 					"data": map[string]any{
-						"getOrganization": map[string]any{
-							"organizationId": "test-org-id",
+						"getCreOrganizationInfo": map[string]any{
+							"orgId":                 "test-org-id",
+							"derivedWorkflowOwners": []string{"ab12cd34ef56ab12cd34ef56ab12cd34ef56ab12"},
 						},
 					},
 				})
@@ -99,11 +100,12 @@ func workflowDeployUnsigned(t *testing.T, tc TestConfig, projectRootFlag, workfl
 			w.Header().Set("Content-Type", "application/json")
 
 			// Handle authentication validation query
-			if strings.Contains(req.Query, "getOrganization") {
+			if strings.Contains(req.Query, "getCreOrganizationInfo") {
 				_ = json.NewEncoder(w).Encode(map[string]any{
 					"data": map[string]any{
-						"getOrganization": map[string]any{
-							"organizationId": "test-org-id",
+						"getCreOrganizationInfo": map[string]any{
+							"orgId":                 "test-org-id",
+							"derivedWorkflowOwners": []string{"ab12cd34ef56ab12cd34ef56ab12cd34ef56ab12"},
 						},
 					},
 				})
@@ -217,11 +219,12 @@ func workflowDeployWithConfigAndLinkedKey(t *testing.T, tc TestConfig, projectRo
 			w.Header().Set("Content-Type", "application/json")
 
 			// Handle authentication validation query
-			if strings.Contains(req.Query, "getOrganization") {
+			if strings.Contains(req.Query, "getCreOrganizationInfo") {
 				_ = json.NewEncoder(w).Encode(map[string]any{
 					"data": map[string]any{
-						"getOrganization": map[string]any{
-							"organizationId": "test-org-id",
+						"getCreOrganizationInfo": map[string]any{
+							"orgId":                 "test-org-id",
+							"derivedWorkflowOwners": []string{"ab12cd34ef56ab12cd34ef56ab12cd34ef56ab12"},
 						},
 					},
 				})

--- a/test/multi_command_flows/workflow_private_registry.go
+++ b/test/multi_command_flows/workflow_private_registry.go
@@ -73,11 +73,12 @@ func workflowDeployPrivateRegistry(t *testing.T, tc TestConfig) string {
 
 			w.Header().Set("Content-Type", "application/json")
 
-			if strings.Contains(req.Query, "getOrganization") {
+			if strings.Contains(req.Query, "getCreOrganizationInfo") {
 				_ = json.NewEncoder(w).Encode(map[string]any{
 					"data": map[string]any{
-						"getOrganization": map[string]any{
-							"organizationId": "test-org-id",
+						"getCreOrganizationInfo": map[string]any{
+							"orgId":                 "test-org-id",
+							"derivedWorkflowOwners": []string{"ab12cd34ef56ab12cd34ef56ab12cd34ef56ab12"},
 						},
 					},
 				})


### PR DESCRIPTION
## Summary
- Replaces the CLI auth validator's getOrganization query with getCreOrganizationInfo, which returns the org ID and the server-derived workflow owner address in a single call
- Adds OrgID and DerivedWorkflowOwner fields to the runtime context, populated during auth validation
- Removes client-side workflow owner derivation (GenerateWorkflowOwnerAddress) from the private registry deploy path — uses the server-provided value instead
- Removes JWT claim parsing for org ID (GetOrgID()) in the deploy command and secrets browser flow — uses the org ID already set by the validator
- Returns a clear error message when the account is not yet fully provisioned