### PR TITLE
Stop sending deprecated onchain related fields for artifacts management

### DIFF
--- a/cmd/workflow/deploy/artifacts.go
+++ b/cmd/workflow/deploy/artifacts.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/smartcontractkit/cre-cli/internal/client/graphqlclient"
 	"github.com/smartcontractkit/cre-cli/internal/client/storageclient"
-	"github.com/smartcontractkit/cre-cli/internal/settings"
 	"github.com/smartcontractkit/cre-cli/internal/ui"
 )
 
@@ -36,17 +35,7 @@ func (h *handler) uploadArtifacts() error {
 
 	gql := graphqlclient.New(h.credentials, h.environmentSet, h.log)
 
-	oc, err := settings.AsOnChain(h.runtimeContext.ResolvedRegistry, "deploy")
-	if err != nil {
-		return err
-	}
-
-	chainSelector, err := settings.GetChainSelectorByChainName(oc.ChainName())
-	if err != nil {
-		return fmt.Errorf("failed to get chain selector for chain %q: %w", oc.ChainName(), err)
-	}
-
-	storageClient := storageclient.New(gql, oc.Address(), h.inputs.WorkflowOwner, chainSelector, h.log)
+	storageClient := storageclient.New(gql, h.inputs.WorkflowOwner, h.log)
 	if h.settings.StorageSettings.CREStorage.ServiceTimeout != 0 {
 		storageClient.SetServiceTimeout(h.settings.StorageSettings.CREStorage.ServiceTimeout)
 	}
@@ -68,6 +57,7 @@ func (h *handler) uploadArtifacts() error {
 
 	if !configFromURL && len(configData) > 0 {
 		ui.Success(fmt.Sprintf("Loaded config from: %s", h.inputs.ConfigPath))
+		var err error
 		configURL, err = storageClient.UploadArtifactWithRetriesAndGetURL(
 			workflowID, storageclient.ArtifactTypeConfig, configData, "text/plain")
 		if err != nil {

--- a/internal/client/storageclient/storageclient.go
+++ b/internal/client/storageclient/storageclient.go
@@ -20,24 +20,20 @@ import (
 )
 
 type Client struct {
-	graphql                 *graphqlclient.Client
-	workflowRegistryAddress string
-	workflowOwnerAddress    string
-	chainSelector           uint64
-	log                     *zerolog.Logger
-	serviceTimeout          time.Duration
-	httpTimeout             time.Duration
+	graphql              *graphqlclient.Client
+	workflowOwnerAddress string
+	log                  *zerolog.Logger
+	serviceTimeout       time.Duration
+	httpTimeout          time.Duration
 }
 
-func New(graphql *graphqlclient.Client, workflowRegistryAddress string, workflowOwnerAddress string, chainSelector uint64, log *zerolog.Logger) *Client {
+func New(graphql *graphqlclient.Client, workflowOwnerAddress string, log *zerolog.Logger) *Client {
 	return &Client{
-		graphql:                 graphql,
-		workflowRegistryAddress: workflowRegistryAddress,
-		workflowOwnerAddress:    workflowOwnerAddress,
-		chainSelector:           chainSelector,
-		log:                     log,
-		serviceTimeout:          time.Minute * 2,
-		httpTimeout:             time.Minute * 1,
+		graphql:              graphql,
+		workflowOwnerAddress: workflowOwnerAddress,
+		log:                  log,
+		serviceTimeout:       time.Minute * 2,
+		httpTimeout:          time.Minute * 1,
 	}
 }
 
@@ -95,12 +91,10 @@ mutation GeneratePresignedPostUrlForArtifact($artifact: GeneratePresignedPostUrl
 	contentHash := calculateContentHash(content)
 	req := graphql.NewRequest(mutation)
 	reqVariables := map[string]any{
-		"workflowId":              workflowId,
-		"artifactType":            artifactType,
-		"contentHash":             contentHash,
-		"workflowOwnerAddress":    c.workflowOwnerAddress,
-		"workflowRegistryAddress": c.workflowRegistryAddress,
-		"chainSelector":           fmt.Sprintf("%v", c.chainSelector),
+		"workflowId":           workflowId,
+		"artifactType":         artifactType,
+		"contentHash":          contentHash,
+		"workflowOwnerAddress": c.workflowOwnerAddress,
 	}
 	req.Var("artifact", reqVariables)
 
@@ -131,10 +125,8 @@ mutation GenerateUnsignedGetUrlForArtifact($artifact: GenerateUnsignedGetUrlRequ
 }`
 	req := graphql.NewRequest(mutation)
 	reqVariables := map[string]any{
-		"workflowId":              workflowId,
-		"artifactType":            artifactType,
-		"workflowRegistryAddress": c.workflowRegistryAddress,
-		"chainSelector":           fmt.Sprintf("%v", c.chainSelector),
+		"workflowId":   workflowId,
+		"artifactType": artifactType,
 	}
 	req.Var("artifact", reqVariables)
 


### PR DESCRIPTION
Artifact managment during workflow deploy should be independant from the onchain registry.