### PR TITLE
Resolve workflow owner by deployment registry

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -271,6 +271,10 @@ func newRootCommand() *cobra.Command {
 					return err
 				}
 
+				if err := runtimeContext.FinalizeDeferredWorkflowOwner(cmd); err != nil {
+					return err
+				}
+
 				// Restart spinner for remaining initialization
 				if showSpinner {
 					spinner = ui.NewSpinner()

--- a/cmd/workflow/activate/activate.go
+++ b/cmd/workflow/activate/activate.go
@@ -133,10 +133,6 @@ func (h *handler) resolveWorkflowOwner(registryType settings.RegistryType) (stri
 		return "", fmt.Errorf("derived workflow owner is not available; ensure authentication succeeded")
 	}
 
-	if len(owner) >= 2 && owner[:2] != "0x" {
-		owner = "0x" + owner
-	}
-
 	return owner, nil
 }
 

--- a/cmd/workflow/delete/delete.go
+++ b/cmd/workflow/delete/delete.go
@@ -108,10 +108,6 @@ func (h *handler) resolveWorkflowOwner() (string, error) {
 		return "", fmt.Errorf("derived workflow owner is not available; ensure authentication succeeded")
 	}
 
-	if len(owner) >= 2 && owner[:2] != "0x" {
-		owner = "0x" + owner
-	}
-
 	return owner, nil
 }
 

--- a/cmd/workflow/deploy/deploy.go
+++ b/cmd/workflow/deploy/deploy.go
@@ -316,10 +316,6 @@ func (h *handler) resolveWorkflowOwner(registryType settings.RegistryType) (stri
 		return "", fmt.Errorf("derived workflow owner is not available; ensure authentication succeeded")
 	}
 
-	if len(owner) >= 2 && owner[:2] != "0x" {
-		owner = "0x" + owner
-	}
-
 	return owner, nil
 }
 

--- a/cmd/workflow/deploy/private_registry_test.go
+++ b/cmd/workflow/deploy/private_registry_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/smartcontractkit/cre-cli/internal/client/privateregistryclient"
 	"github.com/smartcontractkit/cre-cli/internal/credentials"
+	"github.com/smartcontractkit/cre-cli/internal/ethkeys"
 	"github.com/smartcontractkit/cre-cli/internal/settings"
 	"github.com/smartcontractkit/cre-cli/internal/testutil"
 	"github.com/smartcontractkit/cre-cli/internal/testutil/chainsim"
@@ -319,7 +320,9 @@ func TestResolveWorkflowOwner(t *testing.T) {
 
 		expectedBytes, err := workflowUtils.GenerateWorkflowOwnerAddress("42", "org-test-123")
 		require.NoError(t, err)
-		expectedOwner := "0x" + hex.EncodeToString(expectedBytes)
+		rawOwner := "0x" + hex.EncodeToString(expectedBytes)
+		expectedOwner := ethkeys.FormatWorkflowOwnerAddress(rawOwner)
+		require.NotEmpty(t, expectedOwner)
 
 		simulatedEnvironment := chainsim.NewSimulatedEnvironment(t)
 		defer simulatedEnvironment.Close()
@@ -339,29 +342,6 @@ func TestResolveWorkflowOwner(t *testing.T) {
 		owner, err := h.resolveWorkflowOwner(settings.RegistryTypeOffChain)
 		require.NoError(t, err)
 		assert.Equal(t, expectedOwner, owner)
-	})
-
-	t.Run("private target adds 0x prefix when missing", func(t *testing.T) {
-		t.Parallel()
-
-		simulatedEnvironment := chainsim.NewSimulatedEnvironment(t)
-		defer simulatedEnvironment.Close()
-
-		ctx, buf := simulatedEnvironment.NewRuntimeContextWithBufferedOutput()
-		h := newHandler(ctx, buf)
-		ctx.Settings = createTestSettings(
-			chainsim.TestAddress,
-			"eoa",
-			"test_workflow",
-			"testdata/basic_workflow/main.go",
-			"",
-		)
-		h.settings = ctx.Settings
-		h.runtimeContext.DerivedWorkflowOwner = "abcdef1234567890"
-
-		owner, err := h.resolveWorkflowOwner(settings.RegistryTypeOffChain)
-		require.NoError(t, err)
-		assert.Equal(t, "0xabcdef1234567890", owner)
 	})
 
 	t.Run("private target errors when derived workflow owner is empty", func(t *testing.T) {

--- a/cmd/workflow/deploy/private_registry_test.go
+++ b/cmd/workflow/deploy/private_registry_test.go
@@ -321,7 +321,8 @@ func TestResolveWorkflowOwner(t *testing.T) {
 		expectedBytes, err := workflowUtils.GenerateWorkflowOwnerAddress("42", "org-test-123")
 		require.NoError(t, err)
 		rawOwner := "0x" + hex.EncodeToString(expectedBytes)
-		expectedOwner := ethkeys.FormatWorkflowOwnerAddress(rawOwner)
+		expectedOwner, err := ethkeys.FormatWorkflowOwnerAddress(rawOwner)
+		require.NoError(t, err)
 		require.NotEmpty(t, expectedOwner)
 
 		simulatedEnvironment := chainsim.NewSimulatedEnvironment(t).WithPrivateRegistry("42", "test-don")

--- a/cmd/workflow/pause/pause.go
+++ b/cmd/workflow/pause/pause.go
@@ -130,10 +130,6 @@ func (h *handler) resolveWorkflowOwner(registryType settings.RegistryType) (stri
 		return "", fmt.Errorf("derived workflow owner is not available; ensure authentication succeeded")
 	}
 
-	if len(owner) >= 2 && owner[:2] != "0x" {
-		owner = "0x" + owner
-	}
-
 	return owner, nil
 }
 

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -47,8 +47,9 @@ const (
 	AuthListenAddr  = "localhost:53682"
 	CreUiAuthPath   = "/auth/cli"
 
-	WorkflowOwnerTypeEOA  = "EOA"
-	WorkflowOwnerTypeMSIG = "MSIG"
+	WorkflowOwnerTypeEOA        = "EOA"
+	WorkflowOwnerTypeMSIG       = "MSIG"
+	WorkflowOwnerTypeOrgDerived = "ORG_DERIVED"
 
 	WorkflowRegistryV2TypeAndVersion = "WorkflowRegistry 2.0.0"
 

--- a/internal/ethkeys/keys.go
+++ b/internal/ethkeys/keys.go
@@ -10,20 +10,20 @@ import (
 )
 
 // FormatWorkflowOwnerAddress trims whitespace, ensures a 0x prefix for hex input,
-// and returns the address in EIP-55 checksummed form. Returns "" if s is empty
-// or not a valid 20-byte hex address.
-func FormatWorkflowOwnerAddress(s string) string {
+// and returns the address in EIP-55 checksummed form. Empty input (after trim)
+// returns ("", nil). Non-empty input that is not a valid 20-byte hex address returns an error.
+func FormatWorkflowOwnerAddress(s string) (string, error) {
 	s = strings.TrimSpace(s)
 	if s == "" {
-		return ""
+		return "", nil
 	}
 	if len(s) < 2 || (s[0:2] != "0x" && s[0:2] != "0X") {
 		s = "0x" + s
 	}
 	if !common.IsHexAddress(s) {
-		return ""
+		return "", fmt.Errorf("invalid owner address %q", s)
 	}
-	return common.HexToAddress(s).Hex()
+	return common.HexToAddress(s).Hex(), nil
 }
 
 func DeriveEthAddressFromPrivateKey(privateKeyHex string) (string, error) {

--- a/internal/ethkeys/keys.go
+++ b/internal/ethkeys/keys.go
@@ -3,9 +3,28 @@ package ethkeys
 import (
 	"crypto/ecdsa"
 	"fmt"
+	"strings"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 )
+
+// FormatWorkflowOwnerAddress trims whitespace, ensures a 0x prefix for hex input,
+// and returns the address in EIP-55 checksummed form. Returns "" if s is empty
+// or not a valid 20-byte hex address.
+func FormatWorkflowOwnerAddress(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ""
+	}
+	if len(s) < 2 || (s[0:2] != "0x" && s[0:2] != "0X") {
+		s = "0x" + s
+	}
+	if !common.IsHexAddress(s) {
+		return ""
+	}
+	return common.HexToAddress(s).Hex()
+}
 
 func DeriveEthAddressFromPrivateKey(privateKeyHex string) (string, error) {
 	privateKey, err := crypto.HexToECDSA(privateKeyHex)

--- a/internal/ethkeys/keys_test.go
+++ b/internal/ethkeys/keys_test.go
@@ -83,7 +83,10 @@ func TestFormatWorkflowOwnerAddress(t *testing.T) {
 
 	t.Run("trims and checksums", func(t *testing.T) {
 		t.Parallel()
-		got := FormatWorkflowOwnerAddress("  " + addr + "  ")
+		got, err := FormatWorkflowOwnerAddress("  " + addr + "  ")
+		if err != nil {
+			t.Fatal(err)
+		}
 		if got != want {
 			t.Fatalf("got %q want %q", got, want)
 		}
@@ -91,7 +94,10 @@ func TestFormatWorkflowOwnerAddress(t *testing.T) {
 
 	t.Run("adds 0x when missing", func(t *testing.T) {
 		t.Parallel()
-		got := FormatWorkflowOwnerAddress(strings.TrimPrefix(addr, "0x"))
+		got, err := FormatWorkflowOwnerAddress(strings.TrimPrefix(addr, "0x"))
+		if err != nil {
+			t.Fatal(err)
+		}
 		if got != want {
 			t.Fatalf("got %q want %q", got, want)
 		}
@@ -99,18 +105,27 @@ func TestFormatWorkflowOwnerAddress(t *testing.T) {
 
 	t.Run("empty", func(t *testing.T) {
 		t.Parallel()
-		if got := FormatWorkflowOwnerAddress(""); got != "" {
+		got, err := FormatWorkflowOwnerAddress("")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != "" {
 			t.Fatalf("got %q want empty", got)
 		}
-		if got := FormatWorkflowOwnerAddress("   "); got != "" {
+		got, err = FormatWorkflowOwnerAddress("   ")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != "" {
 			t.Fatalf("got %q want empty", got)
 		}
 	})
 
 	t.Run("invalid", func(t *testing.T) {
 		t.Parallel()
-		if got := FormatWorkflowOwnerAddress("not-an-address"); got != "" {
-			t.Fatalf("got %q want empty", got)
+		_, err := FormatWorkflowOwnerAddress("not-an-address")
+		if err == nil {
+			t.Fatal("expected error")
 		}
 	})
 }

--- a/internal/ethkeys/keys_test.go
+++ b/internal/ethkeys/keys_test.go
@@ -74,3 +74,43 @@ func TestDeriveEthAddressFromPrivateKey_InvalidInput(t *testing.T) {
 		})
 	}
 }
+
+func TestFormatWorkflowOwnerAddress(t *testing.T) {
+	t.Parallel()
+
+	addr := "0x1234567890123456789012345678901234567890"
+	want := common.HexToAddress(addr).Hex()
+
+	t.Run("trims and checksums", func(t *testing.T) {
+		t.Parallel()
+		got := FormatWorkflowOwnerAddress("  " + addr + "  ")
+		if got != want {
+			t.Fatalf("got %q want %q", got, want)
+		}
+	})
+
+	t.Run("adds 0x when missing", func(t *testing.T) {
+		t.Parallel()
+		got := FormatWorkflowOwnerAddress(strings.TrimPrefix(addr, "0x"))
+		if got != want {
+			t.Fatalf("got %q want %q", got, want)
+		}
+	})
+
+	t.Run("empty", func(t *testing.T) {
+		t.Parallel()
+		if got := FormatWorkflowOwnerAddress(""); got != "" {
+			t.Fatalf("got %q want empty", got)
+		}
+		if got := FormatWorkflowOwnerAddress("   "); got != "" {
+			t.Fatalf("got %q want empty", got)
+		}
+	})
+
+	t.Run("invalid", func(t *testing.T) {
+		t.Parallel()
+		if got := FormatWorkflowOwnerAddress("not-an-address"); got != "" {
+			t.Fatalf("got %q want empty", got)
+		}
+	})
+}

--- a/internal/runtime/runtime_context.go
+++ b/internal/runtime/runtime_context.go
@@ -109,7 +109,11 @@ func (ctx *Context) AttachCredentials(validationCtx context.Context, skipValidat
 
 		if result != nil {
 			ctx.OrgID = result.OrgID
-			ctx.DerivedWorkflowOwner = ethkeys.FormatWorkflowOwnerAddress(result.DerivedWorkflowOwner)
+			formatted, err := ethkeys.FormatWorkflowOwnerAddress(result.DerivedWorkflowOwner)
+			if err != nil {
+				return fmt.Errorf("%w: %w", ErrValidationFailed, err)
+			}
+			ctx.DerivedWorkflowOwner = formatted
 		}
 	}
 

--- a/internal/runtime/runtime_context.go
+++ b/internal/runtime/runtime_context.go
@@ -13,6 +13,7 @@ import (
 	"github.com/smartcontractkit/cre-cli/internal/authvalidation"
 	"github.com/smartcontractkit/cre-cli/internal/credentials"
 	"github.com/smartcontractkit/cre-cli/internal/environments"
+	"github.com/smartcontractkit/cre-cli/internal/ethkeys"
 	"github.com/smartcontractkit/cre-cli/internal/settings"
 	"github.com/smartcontractkit/cre-cli/internal/tenantctx"
 )
@@ -71,6 +72,22 @@ func (ctx *Context) AttachSettings(cmd *cobra.Command, validateDeployRPC bool) e
 	return nil
 }
 
+// FinalizeDeferredWorkflowOwner fills workflow owner when settings load deferred it
+// (non-empty deployment-registry). Call after AttachResolvedRegistry.
+func (ctx *Context) FinalizeDeferredWorkflowOwner(cmd *cobra.Command) error {
+	if ctx.Settings == nil {
+		return nil
+	}
+	return settings.FinalizeWorkflowOwner(
+		ctx.Viper,
+		cmd,
+		&ctx.Settings.Workflow,
+		ctx.Settings.User.TargetName,
+		ctx.ResolvedRegistry,
+		ctx.DerivedWorkflowOwner,
+	)
+}
+
 func (ctx *Context) AttachCredentials(validationCtx context.Context, skipValidation bool) error {
 	var err error
 
@@ -92,7 +109,7 @@ func (ctx *Context) AttachCredentials(validationCtx context.Context, skipValidat
 
 		if result != nil {
 			ctx.OrgID = result.OrgID
-			ctx.DerivedWorkflowOwner = result.DerivedWorkflowOwner
+			ctx.DerivedWorkflowOwner = ethkeys.FormatWorkflowOwnerAddress(result.DerivedWorkflowOwner)
 		}
 	}
 

--- a/internal/settings/settings_test.go
+++ b/internal/settings/settings_test.go
@@ -69,6 +69,15 @@ func copyFile(src, dest string) error {
 	return err
 }
 
+// workflowSubcommand returns a cobra command that is a child of "workflow", matching
+// how LoadSettingsIntoViper loads workflow.yaml only for workflow commands.
+func workflowSubcommand(use string) *cobra.Command {
+	workflowCmd := &cobra.Command{Use: "workflow"}
+	sub := &cobra.Command{Use: use}
+	workflowCmd.AddCommand(sub)
+	return sub
+}
+
 func TestLoadEnvAndSettingsEmptyTarget(t *testing.T) {
 	envVars := map[string]string{
 		settings.CreTargetEnvVar: "",
@@ -310,7 +319,7 @@ func TestOffChainDeploymentRegistryUsesDerivedOwnerWithoutPrivateKey(t *testing.
 	}
 	envSet := &environments.EnvironmentSet{EnvName: "STAGING"}
 
-	cmd := &cobra.Command{Use: "deploy"}
+	cmd := workflowSubcommand("deploy")
 	s, err := settings.New(logger, v, cmd, "")
 	require.NoError(t, err)
 	require.NotNil(t, s)
@@ -351,7 +360,7 @@ func TestOffChainDeploymentRegistryMissingDerivedOwnerReturnsError(t *testing.T)
 	}
 	envSet := &environments.EnvironmentSet{EnvName: "STAGING"}
 
-	cmd := &cobra.Command{Use: "deploy"}
+	cmd := workflowSubcommand("deploy")
 	s, err := settings.New(logger, v, cmd, "")
 	require.NoError(t, err)
 	resolved, err := settings.ResolveRegistry("my-private-registry", tenantCtx, envSet)
@@ -398,7 +407,7 @@ func TestOnChainDeploymentRegistryStillRequiresPrivateKey(t *testing.T) {
 	}
 	envSet := &environments.EnvironmentSet{EnvName: "STAGING"}
 
-	cmd := &cobra.Command{Use: "deploy"}
+	cmd := workflowSubcommand("deploy")
 	s, err := settings.New(logger, v, cmd, "")
 	require.NoError(t, err)
 	resolved, err := settings.ResolveRegistry("onchain:ethereum-testnet-sepolia", tenantCtx, envSet)

--- a/internal/settings/settings_test.go
+++ b/internal/settings/settings_test.go
@@ -309,7 +309,8 @@ func TestOffChainDeploymentRegistryUsesDerivedOwnerWithoutPrivateKey(t *testing.
 
 	setUpTestSettingsFiles(t, v, workflowTemplatePath, projectTemplatePath, tempDir)
 
-	derived := ethkeys.FormatWorkflowOwnerAddress("  0x1234567890123456789012345678901234567890  ")
+	derived, err := ethkeys.FormatWorkflowOwnerAddress("  0x1234567890123456789012345678901234567890  ")
+	require.NoError(t, err)
 	require.NotEmpty(t, derived)
 	tenantCtx := &tenantctx.EnvironmentContext{
 		DefaultDonFamily: "test-don",

--- a/internal/settings/settings_test.go
+++ b/internal/settings/settings_test.go
@@ -14,7 +14,10 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/cre-cli/internal/constants"
+	"github.com/smartcontractkit/cre-cli/internal/environments"
+	"github.com/smartcontractkit/cre-cli/internal/ethkeys"
 	"github.com/smartcontractkit/cre-cli/internal/settings"
+	"github.com/smartcontractkit/cre-cli/internal/tenantctx"
 	"github.com/smartcontractkit/cre-cli/internal/testutil"
 )
 
@@ -273,6 +276,135 @@ func TestLoadEnvAndSettingsInvalidTarget(t *testing.T) {
 	assert.Error(t, err, "Expected error due to invalid target")
 	assert.Contains(t, err.Error(), "target not found: nonexistent-target", "Expected target not found error")
 	assert.Nil(t, s, "Settings object should be nil on error")
+}
+
+func TestOffChainDeploymentRegistryUsesDerivedOwnerWithoutPrivateKey(t *testing.T) {
+	t.Setenv(settings.EthPrivateKeyEnvVar, "")
+
+	envVars := map[string]string{
+		settings.CreTargetEnvVar: "staging",
+	}
+
+	workflowTemplatePath, err := filepath.Abs(filepath.Join("testdata", "workflow_storage", "workflow-private-registry.yaml"))
+	require.NoError(t, err)
+
+	projectTemplatePath, err := filepath.Abs(TempProjectSettingsFile)
+	require.NoError(t, err)
+
+	tempDir := t.TempDir()
+	restoreWorkingDirectory, err := testutil.ChangeWorkingDirectory(tempDir)
+	require.NoError(t, err)
+	defer restoreWorkingDirectory()
+
+	v, logger := createTestContext(t, envVars, tempDir)
+
+	setUpTestSettingsFiles(t, v, workflowTemplatePath, projectTemplatePath, tempDir)
+
+	derived := ethkeys.FormatWorkflowOwnerAddress("  0x1234567890123456789012345678901234567890  ")
+	require.NotEmpty(t, derived)
+	tenantCtx := &tenantctx.EnvironmentContext{
+		DefaultDonFamily: "test-don",
+		Registries: []*tenantctx.Registry{
+			{ID: "my-private-registry", Type: "off-chain"},
+		},
+	}
+	envSet := &environments.EnvironmentSet{EnvName: "STAGING"}
+
+	cmd := &cobra.Command{Use: "deploy"}
+	s, err := settings.New(logger, v, cmd, "")
+	require.NoError(t, err)
+	require.NotNil(t, s)
+	resolved, err := settings.ResolveRegistry("my-private-registry", tenantCtx, envSet)
+	require.NoError(t, err)
+	err = settings.FinalizeWorkflowOwner(v, cmd, &s.Workflow, s.User.TargetName, resolved, derived)
+	require.NoError(t, err)
+	assert.Equal(t, derived, s.Workflow.UserWorkflowSettings.WorkflowOwnerAddress)
+	assert.Equal(t, constants.WorkflowOwnerTypeOrgDerived, s.Workflow.UserWorkflowSettings.WorkflowOwnerType)
+	assert.Empty(t, s.User.EthPrivateKey)
+}
+
+func TestOffChainDeploymentRegistryMissingDerivedOwnerReturnsError(t *testing.T) {
+	envVars := map[string]string{
+		settings.CreTargetEnvVar: "staging",
+	}
+
+	workflowTemplatePath, err := filepath.Abs(filepath.Join("testdata", "workflow_storage", "workflow-private-registry.yaml"))
+	require.NoError(t, err)
+
+	projectTemplatePath, err := filepath.Abs(TempProjectSettingsFile)
+	require.NoError(t, err)
+
+	tempDir := t.TempDir()
+	restoreWorkingDirectory, err := testutil.ChangeWorkingDirectory(tempDir)
+	require.NoError(t, err)
+	defer restoreWorkingDirectory()
+
+	v, logger := createTestContext(t, envVars, tempDir)
+
+	setUpTestSettingsFiles(t, v, workflowTemplatePath, projectTemplatePath, tempDir)
+
+	tenantCtx := &tenantctx.EnvironmentContext{
+		DefaultDonFamily: "test-don",
+		Registries: []*tenantctx.Registry{
+			{ID: "my-private-registry", Type: "off-chain"},
+		},
+	}
+	envSet := &environments.EnvironmentSet{EnvName: "STAGING"}
+
+	cmd := &cobra.Command{Use: "deploy"}
+	s, err := settings.New(logger, v, cmd, "")
+	require.NoError(t, err)
+	resolved, err := settings.ResolveRegistry("my-private-registry", tenantCtx, envSet)
+	require.NoError(t, err)
+	err = settings.FinalizeWorkflowOwner(v, cmd, &s.Workflow, s.User.TargetName, resolved, "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "derived workflow owner is not available")
+}
+
+func TestOnChainDeploymentRegistryStillRequiresPrivateKey(t *testing.T) {
+	t.Setenv(settings.EthPrivateKeyEnvVar, "")
+
+	envVars := map[string]string{
+		settings.CreTargetEnvVar: "staging",
+	}
+
+	workflowTemplatePath, err := filepath.Abs(filepath.Join("testdata", "workflow_storage", "workflow-onchain-named-registry.yaml"))
+	require.NoError(t, err)
+
+	projectTemplatePath, err := filepath.Abs(TempProjectSettingsFile)
+	require.NoError(t, err)
+
+	tempDir := t.TempDir()
+	restoreWorkingDirectory, err := testutil.ChangeWorkingDirectory(tempDir)
+	require.NoError(t, err)
+	defer restoreWorkingDirectory()
+
+	v, logger := createTestContext(t, envVars, tempDir)
+
+	setUpTestSettingsFiles(t, v, workflowTemplatePath, projectTemplatePath, tempDir)
+
+	chainSel := "16015286601757825753"
+	addr := "0xaE55eB3EDAc48a1163EE2cbb1205bE1e90Ea1135"
+	tenantCtx := &tenantctx.EnvironmentContext{
+		DefaultDonFamily: "zone-a",
+		Registries: []*tenantctx.Registry{
+			{
+				ID:            "onchain:ethereum-testnet-sepolia",
+				Type:          "on-chain",
+				ChainSelector: &chainSel,
+				Address:       &addr,
+			},
+		},
+	}
+	envSet := &environments.EnvironmentSet{EnvName: "STAGING"}
+
+	cmd := &cobra.Command{Use: "deploy"}
+	s, err := settings.New(logger, v, cmd, "")
+	require.NoError(t, err)
+	resolved, err := settings.ResolveRegistry("onchain:ethereum-testnet-sepolia", tenantCtx, envSet)
+	require.NoError(t, err)
+	err = settings.FinalizeWorkflowOwner(v, cmd, &s.Workflow, s.User.TargetName, resolved, "1234567890123456789012345678901234567890")
+	require.Error(t, err)
 }
 
 func TestShouldSkipGetOwner(t *testing.T) {

--- a/internal/settings/testdata/workflow_storage/workflow-onchain-named-registry.yaml
+++ b/internal/settings/testdata/workflow_storage/workflow-onchain-named-registry.yaml
@@ -1,0 +1,9 @@
+# staging target with named on-chain deployment-registry (owner still from key or MSIG)
+staging:
+  user-workflow:
+    workflow-name: "workflowTest"
+    deployment-registry: "onchain:ethereum-testnet-sepolia"
+  workflow-artifacts:
+    workflow-language: "go"
+    workflow-path: "./main.go"
+    config-path: "./config.json"

--- a/internal/settings/testdata/workflow_storage/workflow-private-registry.yaml
+++ b/internal/settings/testdata/workflow_storage/workflow-private-registry.yaml
@@ -1,0 +1,9 @@
+# staging target with private deployment-registry (no workflow-owner-address; owner comes from auth)
+staging:
+  user-workflow:
+    workflow-name: "workflowTest"
+    deployment-registry: "my-private-registry"
+  workflow-artifacts:
+    workflow-language: "go"
+    workflow-path: "./main.go"
+    config-path: "./config.json"

--- a/internal/settings/workflow_settings.go
+++ b/internal/settings/workflow_settings.go
@@ -11,6 +11,8 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"sigs.k8s.io/yaml"
+
+	"github.com/smartcontractkit/cre-cli/internal/constants"
 )
 
 // GetWorkflowPathFromFile reads workflow-path from a workflow.yaml file (same value deploy/simulate get from Settings).
@@ -118,18 +120,23 @@ func loadWorkflowSettings(logger *zerolog.Logger, v *viper.Viper, cmd *cobra.Com
 
 	var workflowSettings WorkflowSettings
 
-	// if a command doesn't need private key, skip getting owner here
+	workflowSettings.UserWorkflowSettings.DeploymentRegistry = getSetting(DeploymentRegistrySettingName)
+	deploymentRegistry := workflowSettings.UserWorkflowSettings.DeploymentRegistry
+
+	// If deployment-registry is set, owner depends on how that id resolves; defer to
+	// FinalizeWorkflowOwner (after ResolveRegistry). Otherwise resolve from env/config now.
 	if !ShouldSkipGetOwner(cmd) {
-		ownerAddress, ownerType, err := GetWorkflowOwner(v)
-		if err != nil {
-			return WorkflowSettings{}, err
+		if deploymentRegistry == "" {
+			ownerAddress, ownerType, err := GetWorkflowOwner(v)
+			if err != nil {
+				return WorkflowSettings{}, err
+			}
+			workflowSettings.UserWorkflowSettings.WorkflowOwnerAddress = ownerAddress
+			workflowSettings.UserWorkflowSettings.WorkflowOwnerType = ownerType
 		}
-		workflowSettings.UserWorkflowSettings.WorkflowOwnerAddress = ownerAddress
-		workflowSettings.UserWorkflowSettings.WorkflowOwnerType = ownerType
 	}
 
 	workflowSettings.UserWorkflowSettings.WorkflowName = getSetting(WorkflowNameSettingName)
-	workflowSettings.UserWorkflowSettings.DeploymentRegistry = getSetting(DeploymentRegistrySettingName)
 	workflowSettings.WorkflowArtifactSettings.WorkflowPath = getSetting(WorkflowPathSettingName)
 	workflowSettings.WorkflowArtifactSettings.ConfigPath = getSetting(ConfigPathSettingName)
 	workflowSettings.WorkflowArtifactSettings.SecretsPath = getSetting(SecretsPathSettingName)
@@ -163,19 +170,61 @@ func loadWorkflowSettings(logger *zerolog.Logger, v *viper.Viper, cmd *cobra.Com
 	// This is required because some commands still read values directly out of viper
 	// TODO: Remove this function once all access to settings no longer uses viper
 	// DEVSVCS-1561
-	if err := flattenWorkflowSettingsToViper(v, target); err != nil {
+	if err := flattenWorkflowSettingsToViper(v, target, workflowSettings.UserWorkflowSettings.WorkflowOwnerAddress); err != nil {
 		return WorkflowSettings{}, err
 	}
 
 	return workflowSettings, nil
 }
 
+// FinalizeWorkflowOwner sets workflow owner when loadWorkflowSettings deferred it because
+// user-workflow.deployment-registry was non-empty. Call after ResolveRegistry.
+func FinalizeWorkflowOwner(
+	v *viper.Viper,
+	cmd *cobra.Command,
+	workflow *WorkflowSettings,
+	target string,
+	resolved ResolvedRegistry,
+	derivedWorkflowOwner string,
+) error {
+	if ShouldSkipGetOwner(cmd) {
+		return nil
+	}
+	if workflow.UserWorkflowSettings.DeploymentRegistry == "" {
+		return nil
+	}
+	if resolved == nil {
+		return fmt.Errorf("resolved registry is required to finalize workflow owner")
+	}
+
+	var ownerAddr, ownerType string
+	var err error
+	if resolved.Type() == RegistryTypeOffChain {
+		ownerAddr = derivedWorkflowOwner
+		if ownerAddr == "" {
+			return fmt.Errorf("derived workflow owner is not available; ensure authentication succeeded")
+		}
+		ownerType = constants.WorkflowOwnerTypeOrgDerived
+	} else {
+		ownerAddr, ownerType, err = GetWorkflowOwner(v)
+		if err != nil {
+			return err
+		}
+	}
+	workflow.UserWorkflowSettings.WorkflowOwnerAddress = ownerAddr
+	workflow.UserWorkflowSettings.WorkflowOwnerType = ownerType
+	return flattenWorkflowSettingsToViper(v, target, ownerAddr)
+}
+
 // TODO: Remove this function once all access to settings no longer uses viper
 // DEVSVCS-1561
-func flattenWorkflowSettingsToViper(v *viper.Viper, target string) error {
-	// Manually flatten the workflow owner setting.
+func flattenWorkflowSettingsToViper(v *viper.Viper, target string, effectiveWorkflowOwner string) error {
+	// Manually flatten the workflow owner setting (effective address from settings load,
+	// including org-derived owner when deployment registry is private).
 	ownerKey := fmt.Sprintf("%s.%s", target, WorkflowOwnerSettingName)
-	if v.IsSet(ownerKey) {
+	if effectiveWorkflowOwner != "" {
+		v.Set(WorkflowOwnerSettingName, effectiveWorkflowOwner)
+	} else if v.IsSet(ownerKey) {
 		owner := v.GetString(ownerKey)
 		v.Set(WorkflowOwnerSettingName, owner)
 	}

--- a/test/multi_command_flows/workflow_private_registry.go
+++ b/test/multi_command_flows/workflow_private_registry.go
@@ -2,6 +2,7 @@ package multi_command_flows
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -12,16 +13,50 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
 
+	"github.com/smartcontractkit/cre-cli/internal/authvalidation"
+	"github.com/smartcontractkit/cre-cli/internal/constants"
+	"github.com/smartcontractkit/cre-cli/internal/credentials"
 	"github.com/smartcontractkit/cre-cli/internal/environments"
+	"github.com/smartcontractkit/cre-cli/internal/ethkeys"
 	"github.com/smartcontractkit/cre-cli/internal/settings"
+	"github.com/smartcontractkit/cre-cli/internal/tenantctx"
+	"github.com/smartcontractkit/cre-cli/internal/testutil"
 	"github.com/smartcontractkit/cre-cli/internal/testutil/testjwt"
 )
 
-const privateRegistryOwnerAddress = "0x0bb6e890f43f93f4f4f5eb64fdf17f81f15bf12a"
+// MockDerivedWorkflowOwnerHex is the raw address (no 0x) in getCreOrganizationInfo.derivedWorkflowOwners
+// in tests. The canonical checksummed form is privateRegistryOwnerAddress.
+const MockDerivedWorkflowOwnerHex = "ab12cd34ef56ab12cd34ef56ab12cd34ef56ab12"
 
-func createTestBearerCredentialsHome(t *testing.T) string {
+var privateRegistryOwnerAddress = mustChecksumMockDerivedOwner()
+
+func mustChecksumMockDerivedOwner() string {
+	s, err := ethkeys.FormatWorkflowOwnerAddress("0x" + MockDerivedWorkflowOwnerHex)
+	if err != nil {
+		panic(err)
+	}
+	return s
+}
+
+// mockGetCreOrganizationInfoGraphQLPayload is the full GraphQL JSON body for getCreOrganizationInfo
+// (shared by composite mocks and graphQLMockOrgInfoOnly).
+func mockGetCreOrganizationInfoGraphQLPayload() map[string]any {
+	return map[string]any{
+		"data": map[string]any{
+			"getCreOrganizationInfo": map[string]any{
+				"orgId":                 "test-org-id",
+				"derivedWorkflowOwners": []string{MockDerivedWorkflowOwnerHex},
+			},
+		},
+	}
+}
+
+// CreateTestBearerCredentialsHome writes JWT bearer credentials under HOME/.cre for subprocess CLI tests.
+func CreateTestBearerCredentialsHome(t *testing.T) string {
 	t.Helper()
 
 	homeDir := t.TempDir()
@@ -44,8 +79,10 @@ func createTestJWT(orgID string) string {
 	return testjwt.CreateTestJWT(orgID)
 }
 
-// workflowDeployPrivateRegistry deploys a workflow to the private registry via CLI
-// using a mock GraphQL + upload server.
+// workflowDeployPrivateRegistry deploys a workflow to the private registry via CLI.
+// It starts a single httptest.Server that mocks GraphQL (getCreOrganizationInfo,
+// GetTenantConfig, GeneratePresignedPostUrlForArtifact, GenerateUnsignedGetUrlForArtifact,
+// listWorkflowOwners, GetOffchainWorkflowByName, UpsertOffchainWorkflow) and POST /upload.
 func workflowDeployPrivateRegistry(t *testing.T, tc TestConfig) string {
 	t.Helper()
 
@@ -62,14 +99,7 @@ func workflowDeployPrivateRegistry(t *testing.T, tc TestConfig) string {
 			w.Header().Set("Content-Type", "application/json")
 
 			if strings.Contains(req.Query, "getCreOrganizationInfo") {
-				_ = json.NewEncoder(w).Encode(map[string]any{
-					"data": map[string]any{
-						"getCreOrganizationInfo": map[string]any{
-							"orgId":                 "test-org-id",
-							"derivedWorkflowOwners": []string{"ab12cd34ef56ab12cd34ef56ab12cd34ef56ab12"},
-						},
-					},
-				})
+				_ = json.NewEncoder(w).Encode(mockGetCreOrganizationInfoGraphQLPayload())
 				return
 			}
 
@@ -207,7 +237,7 @@ func workflowDeployPrivateRegistry(t *testing.T, tc TestConfig) string {
 	}
 
 	cmd := exec.Command(CLIPath, args...)
-	testHome := createTestBearerCredentialsHome(t)
+	testHome := CreateTestBearerCredentialsHome(t)
 
 	realHome, err := os.UserHomeDir()
 	require.NoError(t, err, "failed to get real home dir")
@@ -282,14 +312,7 @@ func workflowPausePrivateRegistry(t *testing.T, tc TestConfig) string {
 			w.Header().Set("Content-Type", "application/json")
 
 			if strings.Contains(req.Query, "getCreOrganizationInfo") {
-				_ = json.NewEncoder(w).Encode(map[string]any{
-					"data": map[string]any{
-						"getCreOrganizationInfo": map[string]any{
-							"orgId":                 "test-org-id",
-							"derivedWorkflowOwners": []string{"ab12cd34ef56ab12cd34ef56ab12cd34ef56ab12"},
-						},
-					},
-				})
+				_ = json.NewEncoder(w).Encode(mockGetCreOrganizationInfoGraphQLPayload())
 				return
 			}
 
@@ -389,7 +412,7 @@ func workflowPausePrivateRegistry(t *testing.T, tc TestConfig) string {
 	}
 
 	cmd := exec.Command(CLIPath, args...)
-	testHome := createTestBearerCredentialsHome(t)
+	testHome := CreateTestBearerCredentialsHome(t)
 
 	realHome, err := os.UserHomeDir()
 	require.NoError(t, err, "failed to get real home dir")
@@ -457,14 +480,7 @@ func workflowActivatePrivateRegistry(t *testing.T, tc TestConfig) string {
 			w.Header().Set("Content-Type", "application/json")
 
 			if strings.Contains(req.Query, "getCreOrganizationInfo") {
-				_ = json.NewEncoder(w).Encode(map[string]any{
-					"data": map[string]any{
-						"getCreOrganizationInfo": map[string]any{
-							"orgId":                 "test-org-id",
-							"derivedWorkflowOwners": []string{"ab12cd34ef56ab12cd34ef56ab12cd34ef56ab12"},
-						},
-					},
-				})
+				_ = json.NewEncoder(w).Encode(mockGetCreOrganizationInfoGraphQLPayload())
 				return
 			}
 
@@ -564,7 +580,7 @@ func workflowActivatePrivateRegistry(t *testing.T, tc TestConfig) string {
 	}
 
 	cmd := exec.Command(CLIPath, args...)
-	testHome := createTestBearerCredentialsHome(t)
+	testHome := CreateTestBearerCredentialsHome(t)
 
 	realHome, err := os.UserHomeDir()
 	require.NoError(t, err, "failed to get real home dir")
@@ -632,14 +648,7 @@ func workflowDeletePrivateRegistry(t *testing.T, tc TestConfig) string {
 			w.Header().Set("Content-Type", "application/json")
 
 			if strings.Contains(req.Query, "getCreOrganizationInfo") {
-				_ = json.NewEncoder(w).Encode(map[string]any{
-					"data": map[string]any{
-						"getCreOrganizationInfo": map[string]any{
-							"orgId":                 "test-org-id",
-							"derivedWorkflowOwners": []string{"ab12cd34ef56ab12cd34ef56ab12cd34ef56ab12"},
-						},
-					},
-				})
+				_ = json.NewEncoder(w).Encode(mockGetCreOrganizationInfoGraphQLPayload())
 				return
 			}
 
@@ -727,7 +736,7 @@ func workflowDeletePrivateRegistry(t *testing.T, tc TestConfig) string {
 	}
 
 	cmd := exec.Command(CLIPath, args...)
-	testHome := createTestBearerCredentialsHome(t)
+	testHome := CreateTestBearerCredentialsHome(t)
 
 	realHome, err := os.UserHomeDir()
 	require.NoError(t, err, "failed to get real home dir")
@@ -772,4 +781,136 @@ func RunWorkflowDeletePrivateRegistryHappyPath(t *testing.T, tc TestConfig) {
 	out := workflowDeletePrivateRegistry(t, tc)
 	require.Contains(t, out, "Workflows deleted successfully", "expected private registry delete success.\nCLI OUTPUT:\n%s", out)
 	require.Contains(t, out, "Deleted workflow ID: 1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef", "expected workflow ID in details.\nCLI OUTPUT:\n%s", out)
+}
+
+func workflowDeployCmd() *cobra.Command {
+	w := &cobra.Command{Use: "workflow"}
+	d := &cobra.Command{Use: "deploy"}
+	w.AddCommand(d)
+	return d
+}
+
+func assertEnvFileHasNoEthPrivateKey(t *testing.T, envPath string) {
+	t.Helper()
+	b, err := os.ReadFile(envPath)
+	require.NoError(t, err)
+	for _, line := range strings.Split(string(b), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		key, val, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		if strings.EqualFold(strings.TrimSpace(key), settings.EthPrivateKeyEnvVar) {
+			if strings.TrimSpace(val) != "" {
+				t.Fatalf("expected %s to be unset in %s, got a non-empty value", settings.EthPrivateKeyEnvVar, envPath)
+			}
+		}
+	}
+}
+
+func graphQLMockOrgInfoOnly(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasPrefix(r.URL.Path, "/graphql") || r.Method != http.MethodPost {
+			http.NotFound(w, r)
+			return
+		}
+		var req struct {
+			Query string `json:"query"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		w.Header().Set("Content-Type", "application/json")
+		if strings.Contains(req.Query, "getCreOrganizationInfo") {
+			require.NoError(t, json.NewEncoder(w).Encode(mockGetCreOrganizationInfoGraphQLPayload()))
+			return
+		}
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"errors":[{"message":"unsupported"}]}`))
+	}))
+}
+
+// RunPrivateRegistryAuthAndSettingsFinalize asserts .env has no private key, runs auth
+// validation against a minimal GraphQL mock (getCreOrganizationInfo), then loads settings
+// from disk and finalizes org-derived workflow owner for deployment-registry reg-test.
+func RunPrivateRegistryAuthAndSettingsFinalize(t *testing.T, envPath, blankWorkflowDir string) {
+	t.Helper()
+	assertEnvFileHasNoEthPrivateKey(t, envPath)
+
+	orgSrv := graphQLMockOrgInfoOnly(t)
+	defer orgSrv.Close()
+	t.Setenv(environments.EnvVarGraphQLURL, orgSrv.URL+"/graphql")
+
+	bearerHome := CreateTestBearerCredentialsHome(t)
+	t.Setenv("HOME", bearerHome)
+	t.Setenv("USERPROFILE", bearerHome)
+
+	logger := testutil.NewTestLogger()
+	creds, err := credentials.New(logger)
+	require.NoError(t, err)
+	require.False(t, creds.IsValidated)
+
+	envSet, err := environments.New()
+	require.NoError(t, err)
+	require.NotEmpty(t, envSet.GraphQLURL)
+
+	val := authvalidation.NewValidator(creds, envSet, logger)
+	result, err := val.ValidateCredentials(context.Background(), creds)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, "test-org-id", result.OrgID)
+
+	derivedFormatted, err := ethkeys.FormatWorkflowOwnerAddress(result.DerivedWorkflowOwner)
+	require.NoError(t, err)
+	wantDerived, err := ethkeys.FormatWorkflowOwnerAddress("0x" + MockDerivedWorkflowOwnerHex)
+	require.NoError(t, err)
+	require.Equal(t, wantDerived, derivedFormatted, "derived owner from mock GQL must match formatted MockDerivedWorkflowOwnerHex")
+
+	restoreWD, err := testutil.ChangeWorkingDirectory(blankWorkflowDir)
+	require.NoError(t, err)
+	defer restoreWD()
+
+	v := viper.New()
+	settings.LoadEnv(logger, v, envPath)
+	cmd := workflowDeployCmd()
+	s, err := settings.New(logger, v, cmd, "")
+	require.NoError(t, err)
+	require.NotNil(t, s)
+	require.Empty(t, s.User.EthPrivateKey, "CRE_ETH_PRIVATE_KEY must be absent")
+	require.Equal(t, "reg-test", s.Workflow.UserWorkflowSettings.DeploymentRegistry)
+	require.Empty(t, s.Workflow.UserWorkflowSettings.WorkflowOwnerAddress, "owner is deferred until finalize when deployment-registry is set")
+	require.Empty(t, s.Workflow.UserWorkflowSettings.WorkflowOwnerType)
+
+	tenantCtx := &tenantctx.EnvironmentContext{
+		DefaultDonFamily: "test-don",
+		Registries: []*tenantctx.Registry{
+			{ID: "reg-test", Type: "OFF_CHAIN"},
+		},
+	}
+	resolved, err := settings.ResolveRegistry("reg-test", tenantCtx, envSet)
+	require.NoError(t, err)
+	require.NotNil(t, resolved)
+	require.Equal(t, settings.RegistryTypeOffChain, resolved.Type())
+
+	err = settings.FinalizeWorkflowOwner(v, cmd, &s.Workflow, s.User.TargetName, resolved, derivedFormatted)
+	require.NoError(t, err)
+	require.Equal(t, derivedFormatted, s.Workflow.UserWorkflowSettings.WorkflowOwnerAddress)
+	require.Equal(t, constants.WorkflowOwnerTypeOrgDerived, s.Workflow.UserWorkflowSettings.WorkflowOwnerType)
+}
+
+// RunPrivateRegistryE2E runs auth/settings finalize (no private key) then the full CLI
+// private-registry lifecycle (deploy, pause, activate, delete) with httptest GraphQL mocks.
+func RunPrivateRegistryE2E(t *testing.T, tc TestConfig, envPath, blankWorkflowDir string) {
+	t.Helper()
+	t.Run("auth_and_settings_finalize_without_private_key", func(t *testing.T) {
+		RunPrivateRegistryAuthAndSettingsFinalize(t, envPath, blankWorkflowDir)
+	})
+	t.Run("cli_private_registry_lifecycle", func(t *testing.T) {
+		RunWorkflowPrivateRegistryHappyPath(t, tc)
+		RunWorkflowPausePrivateRegistryHappyPath(t, tc)
+		RunWorkflowActivatePrivateRegistryHappyPath(t, tc)
+		RunWorkflowDeletePrivateRegistryHappyPath(t, tc)
+	})
 }

--- a/test/multi_command_test.go
+++ b/test/multi_command_test.go
@@ -123,27 +123,24 @@ func TestMultiCommandHappyPaths(t *testing.T) {
 		multi_command_flows.RunHappyPath3bWorkflow(t, tc)
 	})
 
-	// Run workflow private registry happy path: Deploy with deployment-registry
-	t.Run("WorkflowPrivateRegistry_DeployHappyPath", func(t *testing.T) {
+	// Private registry (off-chain): no CRE_ETH_PRIVATE_KEY; org-derived owner from mock GQL,
+	// settings load + finalize, then full CLI lifecycle (see multi_command_flows.RunPrivateRegistryE2E).
+	t.Run("WorkflowPrivateRegistry_E2E", func(t *testing.T) {
 		anvilProc, testEthUrl := initTestEnv(t, "anvil-state.json")
 		defer StopAnvil(anvilProc)
 
-		// Private registry owner derivation needs bearer auth org_id.
 		t.Setenv(environments.EnvVarEnv, "STAGING")
 
-		// Setup environment variables for pre-baked registries from Anvil state dump
 		t.Setenv(environments.EnvVarWorkflowRegistryAddress, "0x5FbDB2315678afecb367f032d93F642f64180aa3")
 		t.Setenv(environments.EnvVarWorkflowRegistryChainName, chainselectors.ANVIL_DEVNET.Name)
 		t.Setenv(environments.EnvVarDonFamily, "test-don")
 
 		tc := NewTestConfig(t)
 
-		// Use linked Address3 + its key
-		require.NoError(t, createCliEnvFile(tc.EnvFile, constants.TestPrivateKey3), "failed to create env file")
+		require.NoError(t, createCliEnvFile(tc.EnvFile, ""), "failed to create env file without private key")
 		require.NoError(t, createProjectSettingsFile(tc.ProjectDirectory+"project.yaml", "", testEthUrl), "failed to create project.yaml")
 		require.NoError(t, createWorkflowDirectory(tc.ProjectDirectory, "private-registry-happy-path-workflow", "", "blank_workflow"), "failed to create workflow directory")
 
-		// Set deployment-registry to reg-test to trigger private registry path
 		v := viper.New()
 		v.SetConfigFile(filepath.Join(tc.ProjectDirectory, "blank_workflow", constants.DefaultWorkflowSettingsFileName))
 		require.NoError(t, v.ReadInConfig())
@@ -152,10 +149,7 @@ func TestMultiCommandHappyPaths(t *testing.T) {
 
 		t.Cleanup(tc.Cleanup(t))
 
-		multi_command_flows.RunWorkflowPrivateRegistryHappyPath(t, tc)
-		multi_command_flows.RunWorkflowPausePrivateRegistryHappyPath(t, tc)
-		multi_command_flows.RunWorkflowActivatePrivateRegistryHappyPath(t, tc)
-		multi_command_flows.RunWorkflowDeletePrivateRegistryHappyPath(t, tc)
+		multi_command_flows.RunPrivateRegistryE2E(t, tc, tc.EnvFile, filepath.Join(tc.ProjectDirectory, "blank_workflow"))
 	})
 
 	// Run Account Happy Path: Link -> List -> Unlink -> List (verify unlinked)


### PR DESCRIPTION
When user-workflow.deployment-registry is set, workflow owner is no longer resolved during the first settings load (which required a local key even for off-chain registries). Owner is filled after the registry is resolved: off-chain uses the session-derived owner with type ORG_DERIVED; on-chain still uses GetWorkflowOwner. Derived owner is normalized once when credentials are validated (FormatWorkflowOwnerAddress). Per-command 0x prefix handling in workflow handlers is removed. Tests and workflow fixture YAMLs added/updated.