### PR TITLE
Replace `gql` error with a cre specific one

### DIFF
--- a/internal/client/graphqlclient/graphqlclient.go
+++ b/internal/client/graphqlclient/graphqlclient.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"regexp"
 	"strings"
@@ -62,7 +63,14 @@ func (c *Client) Execute(ctx context.Context, req *graphql.Request, resp any) er
 			req.Header.Set("Authorization", "Bearer "+c.creds.Tokens.AccessToken)
 		}
 	}
-	return c.client.Run(ctx, req, resp)
+	err = c.client.Run(ctx, req, resp)
+	if err != nil {
+		if strings.HasPrefix(err.Error(), "graphql: ") {
+			return errors.New(strings.Replace(err.Error(), "graphql: ", "cre api client: ", 1))
+		}
+		return err
+	}
+	return nil
 }
 
 func (c *Client) refreshTokens(ctx context.Context) error {

--- a/internal/client/graphqlclient/graphqlclient.go
+++ b/internal/client/graphqlclient/graphqlclient.go
@@ -66,7 +66,7 @@ func (c *Client) Execute(ctx context.Context, req *graphql.Request, resp any) er
 	err = c.client.Run(ctx, req, resp)
 	if err != nil {
 		if strings.HasPrefix(err.Error(), "graphql: ") {
-			return errors.New(strings.Replace(err.Error(), "graphql: ", "cre api client: ", 1))
+			return errors.New(strings.Replace(err.Error(), "graphql: ", "cre api error: ", 1))
 		}
 		return err
 	}

--- a/internal/client/graphqlclient/graphqlclient_test.go
+++ b/internal/client/graphqlclient/graphqlclient_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/machinebox/graphql"
 	"github.com/rs/zerolog"
+
 	"github.com/smartcontractkit/cre-cli/internal/credentials"
 	"github.com/smartcontractkit/cre-cli/internal/environments"
 )
@@ -64,7 +65,7 @@ func TestExecute_ErrorPrefixReplacement(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		// This will cause the machinebox/graphql client to return an error starting with "graphql: "
-		w.Write([]byte(`{"errors": [{"message": "DON family \"zone-a\" is not supported"}]}`))
+		_, _ = w.Write([]byte(`{"errors": [{"message": "DON family \"zone-a\" is not supported"}]}`))
 	}))
 	defer srv.Close()
 
@@ -74,18 +75,18 @@ func TestExecute_ErrorPrefixReplacement(t *testing.T) {
 	}
 	envSet := &environments.EnvironmentSet{GraphQLURL: srv.URL}
 	logger := zerolog.Nop()
-	
+
 	client := New(creds, envSet, &logger)
-	
+
 	req := graphql.NewRequest(`query { test }`)
 	var resp interface{}
-	
+
 	err := client.Execute(context.Background(), req, &resp)
-	
+
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
-	
+
 	expectedErr := "cre api client: DON family \"zone-a\" is not supported"
 	if err.Error() != expectedErr {
 		t.Errorf("expected error %q, got %q", expectedErr, err.Error())

--- a/internal/client/graphqlclient/graphqlclient_test.go
+++ b/internal/client/graphqlclient/graphqlclient_test.go
@@ -1,7 +1,15 @@
 package graphqlclient
 
 import (
+	"context"
+	"net/http"
+	"net/http/httptest"
 	"testing"
+
+	"github.com/machinebox/graphql"
+	"github.com/rs/zerolog"
+	"github.com/smartcontractkit/cre-cli/internal/credentials"
+	"github.com/smartcontractkit/cre-cli/internal/environments"
 )
 
 func TestRedactSensitiveHeaders(t *testing.T) {
@@ -49,5 +57,37 @@ func TestRedactSensitiveHeaders(t *testing.T) {
 				t.Errorf("redactSensitiveHeaders(%q) = %q, want %q", tt.input, result, tt.expected)
 			}
 		})
+	}
+}
+
+func TestExecute_ErrorPrefixReplacement(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// This will cause the machinebox/graphql client to return an error starting with "graphql: "
+		w.Write([]byte(`{"errors": [{"message": "DON family \"zone-a\" is not supported"}]}`))
+	}))
+	defer srv.Close()
+
+	creds := &credentials.Credentials{
+		AuthType: credentials.AuthTypeApiKey,
+		APIKey:   "test-api-key",
+	}
+	envSet := &environments.EnvironmentSet{GraphQLURL: srv.URL}
+	logger := zerolog.Nop()
+	
+	client := New(creds, envSet, &logger)
+	
+	req := graphql.NewRequest(`query { test }`)
+	var resp interface{}
+	
+	err := client.Execute(context.Background(), req, &resp)
+	
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	
+	expectedErr := "cre api client: DON family \"zone-a\" is not supported"
+	if err.Error() != expectedErr {
+		t.Errorf("expected error %q, got %q", expectedErr, err.Error())
 	}
 }

--- a/internal/client/graphqlclient/graphqlclient_test.go
+++ b/internal/client/graphqlclient/graphqlclient_test.go
@@ -87,7 +87,7 @@ func TestExecute_ErrorPrefixReplacement(t *testing.T) {
 		t.Fatal("expected error, got nil")
 	}
 
-	expectedErr := "cre api client: DON family \"zone-a\" is not supported"
+	expectedErr := "cre api error: DON family \"zone-a\" is not supported"
 	if err.Error() != expectedErr {
 		t.Errorf("expected error %q, got %q", expectedErr, err.Error())
 	}

--- a/internal/client/privateregistryclient/privateregistryclient_test.go
+++ b/internal/client/privateregistryclient/privateregistryclient_test.go
@@ -196,7 +196,7 @@ func TestUpsertWorkflowInRegistry_GQLError(t *testing.T) {
 	})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "upsert workflow in registry")
-	assert.Contains(t, err.Error(), "cre api client: upsert failed")
+	assert.Contains(t, err.Error(), "cre api error: upsert failed")
 	assert.NotContains(t, err.Error(), "graphql:")
 }
 
@@ -265,7 +265,7 @@ func TestGetWorkflowByName_GQLError(t *testing.T) {
 	_, err := client.GetWorkflowByName("registry-workflow")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "get workflow by name in registry")
-	assert.Contains(t, err.Error(), "cre api client: workflow not found")
+	assert.Contains(t, err.Error(), "cre api error: workflow not found")
 	assert.NotContains(t, err.Error(), "graphql:")
 }
 

--- a/internal/client/privateregistryclient/privateregistryclient_test.go
+++ b/internal/client/privateregistryclient/privateregistryclient_test.go
@@ -196,6 +196,8 @@ func TestUpsertWorkflowInRegistry_GQLError(t *testing.T) {
 	})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "upsert workflow in registry")
+	assert.Contains(t, err.Error(), "cre api client: upsert failed")
+	assert.NotContains(t, err.Error(), "graphql:")
 }
 
 func TestGetWorkflowByName(t *testing.T) {
@@ -263,6 +265,8 @@ func TestGetWorkflowByName_GQLError(t *testing.T) {
 	_, err := client.GetWorkflowByName("registry-workflow")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "get workflow by name in registry")
+	assert.Contains(t, err.Error(), "cre api client: workflow not found")
+	assert.NotContains(t, err.Error(), "graphql:")
 }
 
 func TestGetWorkflowByName_EmptyName(t *testing.T) {


### PR DESCRIPTION
Hide implementation details from the error message

Before:
```
✗ failed to register workflow in private registry: upsert workflow in registry: graphql: DON family "zone-a" is not supported
```

After replacing:
```
✗ failed to register workflow in private registry: upsert workflow in registry: cre api error: DON family "zone-a" is not supported
```