### PR TITLE
refactor(settings): consolidate chain signing keys behind ChainType

### DIFF
--- a/cmd/secrets/common/handler.go
+++ b/cmd/secrets/common/handler.go
@@ -73,13 +73,13 @@ type Handler struct {
 func NewHandler(ctx *runtime.Context, secretsFilePath string) (*Handler, error) {
 	var pk *ecdsa.PrivateKey
 	var err error
-	if ctx.Settings.User.EthPrivateKey != "" {
-		pk, err = crypto.HexToECDSA(ctx.Settings.User.EthPrivateKey)
+	if ethKey := ctx.Settings.User.PrivateKey(settings.EVM); ethKey != "" {
+		pk, err = crypto.HexToECDSA(ethKey)
 		if err != nil {
 			return nil, fmt.Errorf("failed to decode the provided private key: %w", err)
 		}
 	} else {
-		ctx.Logger.Debug().Msg("No EthPrivateKey found in settings; assuming a multisig request.")
+		ctx.Logger.Debug().Msg("No EVM private key found in settings; assuming a multisig request.")
 
 	}
 

--- a/cmd/workflow/activate/activate_test.go
+++ b/cmd/workflow/activate/activate_test.go
@@ -20,7 +20,7 @@ func TestNonInteractive_WithoutYes_ReturnsError(t *testing.T) {
 	ctx := simulatedEnvironment.NewRuntimeContext()
 	ctx.Settings = &settings.Settings{
 		User: settings.UserSettings{
-			EthPrivateKey: chainsim.TestPrivateKey,
+			PrivateKeys: map[string]string{settings.EVM.Name: chainsim.TestPrivateKey},
 		},
 	}
 	ctx.Settings.Workflow.UserWorkflowSettings.WorkflowOwnerType = constants.WorkflowOwnerTypeEOA
@@ -47,7 +47,7 @@ func TestNonInteractive_WithYes_PassesGuard(t *testing.T) {
 	ctx := simulatedEnvironment.NewRuntimeContext()
 	ctx.Settings = &settings.Settings{
 		User: settings.UserSettings{
-			EthPrivateKey: chainsim.TestPrivateKey,
+			PrivateKeys: map[string]string{settings.EVM.Name: chainsim.TestPrivateKey},
 		},
 	}
 	ctx.Settings.Workflow.UserWorkflowSettings.WorkflowOwnerType = constants.WorkflowOwnerTypeEOA
@@ -162,7 +162,7 @@ func TestWorkflowActivateCommand(t *testing.T) {
 				ctx := simulatedEnvironment.NewRuntimeContext()
 				ctx.Settings = &settings.Settings{
 					User: settings.UserSettings{
-						EthPrivateKey: chainsim.TestPrivateKey,
+						PrivateKeys: map[string]string{settings.EVM.Name: chainsim.TestPrivateKey},
 					},
 				}
 				ctx.Settings.Workflow.UserWorkflowSettings.WorkflowOwnerType = constants.WorkflowOwnerTypeEOA

--- a/cmd/workflow/delete/delete_test.go
+++ b/cmd/workflow/delete/delete_test.go
@@ -21,7 +21,7 @@ func TestNonInteractive_WithoutYes_ReturnsError(t *testing.T) {
 	ctx := simulatedEnvironment.NewRuntimeContext()
 	ctx.Settings = &settings.Settings{
 		User: settings.UserSettings{
-			EthPrivateKey: chainsim.TestPrivateKey,
+			PrivateKeys: map[string]string{settings.EVM.Name: chainsim.TestPrivateKey},
 		},
 	}
 	ctx.Settings.Workflow.UserWorkflowSettings.WorkflowOwnerType = constants.WorkflowOwnerTypeEOA
@@ -47,7 +47,7 @@ func TestNonInteractive_WithYes_Proceeds(t *testing.T) {
 	ctx := simulatedEnvironment.NewRuntimeContext()
 	ctx.Settings = &settings.Settings{
 		User: settings.UserSettings{
-			EthPrivateKey: chainsim.TestPrivateKey,
+			PrivateKeys: map[string]string{settings.EVM.Name: chainsim.TestPrivateKey},
 		},
 	}
 	ctx.Settings.Workflow.UserWorkflowSettings.WorkflowOwnerType = constants.WorkflowOwnerTypeEOA
@@ -134,7 +134,7 @@ func TestWorkflowDeleteCommand(t *testing.T) {
 				ctx := simulatedEnvironment.NewRuntimeContext()
 				ctx.Settings = &settings.Settings{
 					User: settings.UserSettings{
-						EthPrivateKey: chainsim.TestPrivateKey,
+						PrivateKeys: map[string]string{settings.EVM.Name: chainsim.TestPrivateKey},
 					},
 				}
 				ctx.Settings.Workflow.UserWorkflowSettings.WorkflowOwnerType = constants.WorkflowOwnerTypeEOA

--- a/cmd/workflow/pause/pause_test.go
+++ b/cmd/workflow/pause/pause_test.go
@@ -20,7 +20,7 @@ func TestNonInteractive_WithoutYes_ReturnsError(t *testing.T) {
 	ctx := simulatedEnvironment.NewRuntimeContext()
 	ctx.Settings = &settings.Settings{
 		User: settings.UserSettings{
-			EthPrivateKey: chainsim.TestPrivateKey,
+			PrivateKeys: map[string]string{settings.EVM.Name: chainsim.TestPrivateKey},
 		},
 	}
 	ctx.Settings.Workflow.UserWorkflowSettings.WorkflowOwnerType = constants.WorkflowOwnerTypeEOA
@@ -46,7 +46,7 @@ func TestNonInteractive_WithYes_PassesGuard(t *testing.T) {
 	ctx := simulatedEnvironment.NewRuntimeContext()
 	ctx.Settings = &settings.Settings{
 		User: settings.UserSettings{
-			EthPrivateKey: chainsim.TestPrivateKey,
+			PrivateKeys: map[string]string{settings.EVM.Name: chainsim.TestPrivateKey},
 		},
 	}
 	ctx.Settings.Workflow.UserWorkflowSettings.WorkflowOwnerType = constants.WorkflowOwnerTypeEOA
@@ -140,7 +140,7 @@ func TestWorkflowPauseCommand(t *testing.T) {
 				ctx := simulatedEnvironment.NewRuntimeContext()
 				ctx.Settings = &settings.Settings{
 					User: settings.UserSettings{
-						EthPrivateKey: chainsim.TestPrivateKey,
+						PrivateKeys: map[string]string{settings.EVM.Name: chainsim.TestPrivateKey},
 					},
 				}
 				ctx.Settings.Workflow.UserWorkflowSettings.WorkflowOwnerType = constants.WorkflowOwnerTypeEOA

--- a/cmd/workflow/simulate/chain/aptos/chaintype.go
+++ b/cmd/workflow/simulate/chain/aptos/chaintype.go
@@ -107,7 +107,7 @@ func (ct *AptosChainType) ResolveClients(v *viper.Viper) (chain.ResolvedChains, 
 }
 
 func (ct *AptosChainType) ResolveKey(s *settings.Settings, broadcast bool) (interface{}, error) {
-	seed := strings.TrimPrefix(strings.ToLower(strings.TrimSpace(s.User.AptosPrivateKey)), "0x")
+	seed := strings.TrimPrefix(strings.ToLower(strings.TrimSpace(s.User.PrivateKey(settings.Aptos))), "0x")
 	bytes, err := hex.DecodeString(seed)
 	if err != nil || len(bytes) != 32 {
 		if broadcast {

--- a/cmd/workflow/simulate/chain/aptos/chaintype_test.go
+++ b/cmd/workflow/simulate/chain/aptos/chaintype_test.go
@@ -12,7 +12,7 @@ import (
 func TestResolveKey_SentinelUnderBroadcastFails(t *testing.T) {
 	t.Parallel()
 	ct := &AptosChainType{}
-	s := &settings.Settings{User: settings.UserSettings{AptosPrivateKey: "0000000000000000000000000000000000000000000000000000000000000001"}}
+	s := &settings.Settings{User: settings.UserSettings{PrivateKeys: map[string]string{settings.Aptos.Name: "0000000000000000000000000000000000000000000000000000000000000001"}}}
 	_, err := ct.ResolveKey(s, true)
 	require.Error(t, err)
 }
@@ -20,7 +20,7 @@ func TestResolveKey_SentinelUnderBroadcastFails(t *testing.T) {
 func TestResolveKey_UnparseableUnderBroadcastFails(t *testing.T) {
 	t.Parallel()
 	ct := &AptosChainType{}
-	s := &settings.Settings{User: settings.UserSettings{AptosPrivateKey: "not-hex"}}
+	s := &settings.Settings{User: settings.UserSettings{PrivateKeys: map[string]string{settings.Aptos.Name: "not-hex"}}}
 	_, err := ct.ResolveKey(s, true)
 	require.Error(t, err)
 }
@@ -28,7 +28,7 @@ func TestResolveKey_UnparseableUnderBroadcastFails(t *testing.T) {
 func TestResolveKey_UnparseableNonBroadcastFallsBackToSentinel(t *testing.T) {
 	t.Parallel()
 	ct := &AptosChainType{}
-	s := &settings.Settings{User: settings.UserSettings{AptosPrivateKey: ""}}
+	s := &settings.Settings{User: settings.UserSettings{PrivateKeys: map[string]string{settings.Aptos.Name: ""}}}
 	k, err := ct.ResolveKey(s, false)
 	require.NoError(t, err)
 	assert.NotNil(t, k)
@@ -37,7 +37,7 @@ func TestResolveKey_UnparseableNonBroadcastFallsBackToSentinel(t *testing.T) {
 func TestResolveKey_ValidKeyBroadcast(t *testing.T) {
 	t.Parallel()
 	ct := &AptosChainType{}
-	s := &settings.Settings{User: settings.UserSettings{AptosPrivateKey: "1111111111111111111111111111111111111111111111111111111111111111"}}
+	s := &settings.Settings{User: settings.UserSettings{PrivateKeys: map[string]string{settings.Aptos.Name: "1111111111111111111111111111111111111111111111111111111111111111"}}}
 	k, err := ct.ResolveKey(s, true)
 	require.NoError(t, err)
 	assert.NotNil(t, k)

--- a/cmd/workflow/simulate/chain/aptos/simulator_scenarios_test.go
+++ b/cmd/workflow/simulate/chain/aptos/simulator_scenarios_test.go
@@ -343,13 +343,13 @@ func simulatorScenarios() []simScenario {
 		}},
 		{name: "28 ResolveKey sentinel OK under dry-run", run: func(t *testing.T) {
 			ct := &AptosChainType{}
-			k, err := ct.ResolveKey(&settings.Settings{User: settings.UserSettings{AptosPrivateKey: ""}}, false)
+			k, err := ct.ResolveKey(&settings.Settings{User: settings.UserSettings{PrivateKeys: map[string]string{settings.Aptos.Name: ""}}}, false)
 			require.NoError(t, err)
 			require.NotNil(t, k)
 		}},
 		{name: "29 ResolveKey rejects sentinel under --broadcast", run: func(t *testing.T) {
 			ct := &AptosChainType{}
-			_, err := ct.ResolveKey(&settings.Settings{User: settings.UserSettings{AptosPrivateKey: defaultSentinelAptosSeed}}, true)
+			_, err := ct.ResolveKey(&settings.Settings{User: settings.UserSettings{PrivateKeys: map[string]string{settings.Aptos.Name: defaultSentinelAptosSeed}}}, true)
 			require.Error(t, err)
 		}},
 		// --- chain-type plugin surface (31-45) ---
@@ -417,28 +417,28 @@ func simulatorScenarios() []simScenario {
 		}},
 		{name: "42 ResolveKey parses 0x-prefixed seed", run: func(t *testing.T) {
 			ct := &AptosChainType{}
-			s := &settings.Settings{User: settings.UserSettings{AptosPrivateKey: "0x2222222222222222222222222222222222222222222222222222222222222222"}}
+			s := &settings.Settings{User: settings.UserSettings{PrivateKeys: map[string]string{settings.Aptos.Name: "0x2222222222222222222222222222222222222222222222222222222222222222"}}}
 			k, err := ct.ResolveKey(s, true)
 			require.NoError(t, err)
 			require.NotNil(t, k)
 		}},
 		{name: "43 ResolveKey parses uppercase hex", run: func(t *testing.T) {
 			ct := &AptosChainType{}
-			s := &settings.Settings{User: settings.UserSettings{AptosPrivateKey: "AABBCCDDEEFF00112233445566778899AABBCCDDEEFF00112233445566778899"}}
+			s := &settings.Settings{User: settings.UserSettings{PrivateKeys: map[string]string{settings.Aptos.Name: "AABBCCDDEEFF00112233445566778899AABBCCDDEEFF00112233445566778899"}}}
 			k, err := ct.ResolveKey(s, true)
 			require.NoError(t, err)
 			require.NotNil(t, k)
 		}},
 		{name: "44 ResolveKey trims whitespace", run: func(t *testing.T) {
 			ct := &AptosChainType{}
-			s := &settings.Settings{User: settings.UserSettings{AptosPrivateKey: "  1111111111111111111111111111111111111111111111111111111111111111  "}}
+			s := &settings.Settings{User: settings.UserSettings{PrivateKeys: map[string]string{settings.Aptos.Name: "  1111111111111111111111111111111111111111111111111111111111111111  "}}}
 			k, err := ct.ResolveKey(s, true)
 			require.NoError(t, err)
 			require.NotNil(t, k)
 		}},
 		{name: "45 ResolveKey short seed hard-fails under broadcast", run: func(t *testing.T) {
 			ct := &AptosChainType{}
-			s := &settings.Settings{User: settings.UserSettings{AptosPrivateKey: "0102"}}
+			s := &settings.Settings{User: settings.UserSettings{PrivateKeys: map[string]string{settings.Aptos.Name: "0102"}}}
 			_, err := ct.ResolveKey(s, true)
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), "CRE_APTOS_PRIVATE_KEY")

--- a/cmd/workflow/simulate/chain/evm/chaintype.go
+++ b/cmd/workflow/simulate/chain/evm/chaintype.go
@@ -225,7 +225,7 @@ func (ct *EVMChainType) RunHealthCheck(resolved chain.ResolvedChains) error {
 // is true, an invalid or default-sentinel key is a hard error. Otherwise a
 // sentinel key is used with a warning so non-broadcast simulations can run.
 func (ct *EVMChainType) ResolveKey(creSettings *settings.Settings, broadcast bool) (interface{}, error) {
-	pk, err := crypto.HexToECDSA(creSettings.User.EthPrivateKey)
+	pk, err := crypto.HexToECDSA(creSettings.User.PrivateKey(settings.EVM))
 	if err != nil {
 		if broadcast {
 			return nil, fmt.Errorf(

--- a/cmd/workflow/simulate/chain/evm/chaintype_test.go
+++ b/cmd/workflow/simulate/chain/evm/chaintype_test.go
@@ -163,7 +163,7 @@ func TestEVMChainType_ResolveKey(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ct := newEVMChainType()
-			s := &settings.Settings{User: settings.UserSettings{EthPrivateKey: tt.pk}}
+			s := &settings.Settings{User: settings.UserSettings{PrivateKeys: map[string]string{settings.EVM.Name: tt.pk}}}
 
 			var got interface{}
 			var err error

--- a/cmd/workflow/simulate/simulate_test.go
+++ b/cmd/workflow/simulate/simulate_test.go
@@ -73,7 +73,7 @@ func TestBlankWorkflowSimulation(t *testing.T) {
 			Workflow: workflowSettings,
 			User: settings.UserSettings{
 				TargetName:    "staging-settings",
-				EthPrivateKey: "88888845d8761ca4a8cefb324c89702f12114ffbd0c47222f12aac0ad6538888",
+				PrivateKeys: map[string]string{settings.EVM.Name: "88888845d8761ca4a8cefb324c89702f12114ffbd0c47222f12aac0ad6538888"},
 			},
 		},
 	}
@@ -125,7 +125,7 @@ func createSimulateTestSettings(workflowName, workflowPath, configPath string) *
 			},
 		},
 		User: settings.UserSettings{
-			EthPrivateKey: "88888845d8761ca4a8cefb324c89702f12114ffbd0c47222f12aac0ad6538888",
+			PrivateKeys: map[string]string{settings.EVM.Name: "88888845d8761ca4a8cefb324c89702f12114ffbd0c47222f12aac0ad6538888"},
 		},
 	}
 }
@@ -446,7 +446,7 @@ func TestSimulateConfigFlagsMutuallyExclusive(t *testing.T) {
 		Viper:  viper.New(),
 		Settings: &settings.Settings{
 			User: settings.UserSettings{
-				EthPrivateKey: "88888845d8761ca4a8cefb324c89702f12114ffbd0c47222f12aac0ad6538888",
+				PrivateKeys: map[string]string{settings.EVM.Name: "88888845d8761ca4a8cefb324c89702f12114ffbd0c47222f12aac0ad6538888"},
 			},
 		},
 	}

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -12,14 +12,37 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
+	corekeys "github.com/smartcontractkit/chainlink-common/keystore/corekeys"
+
 	"github.com/smartcontractkit/cre-cli/internal/ui"
 )
 
-// sensitive information (not in configuration file)
-const (
-	EthPrivateKeyEnvVar   = "CRE_ETH_PRIVATE_KEY"
-	AptosPrivateKeyEnvVar = "CRE_APTOS_PRIVATE_KEY"
-	CreTargetEnvVar       = "CRE_TARGET"
+const CreTargetEnvVar = "CRE_TARGET"
+
+// ChainType describes a chain family and the per-family settings the CLI
+// loads from the environment. Add a family by appending to AllChainTypes.
+type ChainType struct {
+	Name          string
+	PrivateKeyEnv string
+}
+
+var (
+	EVM = ChainType{
+		Name:          string(corekeys.EVM),
+		PrivateKeyEnv: "CRE_ETH_PRIVATE_KEY",
+	}
+	Aptos = ChainType{
+		Name:          string(corekeys.Aptos),
+		PrivateKeyEnv: "CRE_APTOS_PRIVATE_KEY",
+	}
+
+	AllChainTypes = []ChainType{EVM, Aptos}
+)
+
+// Backwards-compat aliases; prefer EVM.PrivateKeyEnv / Aptos.PrivateKeyEnv.
+var (
+	EthPrivateKeyEnvVar   = EVM.PrivateKeyEnv
+	AptosPrivateKeyEnvVar = Aptos.PrivateKeyEnv
 )
 
 // State tracked by LoadEnv / LoadPublicEnv so downstream code (e.g. build
@@ -57,10 +80,16 @@ type Settings struct {
 
 // UserSettings stores user-specific configurations.
 type UserSettings struct {
-	TargetName      string
-	EthPrivateKey   string
-	EthUrl          string
-	AptosPrivateKey string
+	TargetName  string
+	PrivateKeys map[string]string // keyed by ChainType.Name
+}
+
+// PrivateKey returns the signing key for the given chain, or "" if unset.
+func (u UserSettings) PrivateKey(f ChainType) string {
+	if u.PrivateKeys == nil {
+		return ""
+	}
+	return u.PrivateKeys[f.Name]
 }
 
 // New initializes and loads settings from YAML config files and the environment.
@@ -103,17 +132,15 @@ func New(logger *zerolog.Logger, v *viper.Viper, cmd *cobra.Command, registryCha
 		return nil, err
 	}
 
-	rawPrivKey := v.GetString(EthPrivateKeyEnvVar)
-	normPrivKey := NormalizeHexKey(rawPrivKey)
-
-	rawAptosKey := v.GetString(AptosPrivateKeyEnvVar)
-	normAptosKey := NormalizeHexKey(rawAptosKey)
+	privateKeys := make(map[string]string, len(AllChainTypes))
+	for _, f := range AllChainTypes {
+		privateKeys[f.Name] = NormalizeHexKey(v.GetString(f.PrivateKeyEnv))
+	}
 
 	return &Settings{
 		User: UserSettings{
-			EthPrivateKey:   normPrivKey,
-			AptosPrivateKey: normAptosKey,
-			TargetName:      target,
+			TargetName:  target,
+			PrivateKeys: privateKeys,
 		},
 		Workflow:        workflowSettings,
 		StorageSettings: storageSettings,
@@ -169,7 +196,11 @@ func LoadEnv(logger *zerolog.Logger, v *viper.Viper, envPath string) {
 	loadedEnvFilePath = ""
 	loadedEnvVars = nil
 	loadedEnvFilePath, loadedEnvVars = loadEnvFile(logger, envPath)
-	bindAllVars(v, loadedEnvVars, EthPrivateKeyEnvVar, AptosPrivateKeyEnvVar, CreTargetEnvVar)
+	extras := []string{CreTargetEnvVar}
+	for _, f := range AllChainTypes {
+		extras = append(extras, f.PrivateKeyEnv)
+	}
+	bindAllVars(v, loadedEnvVars, extras...)
 }
 
 // LoadPublicEnv loads variables from envPath into the process environment

--- a/internal/settings/settings_test.go
+++ b/internal/settings/settings_test.go
@@ -136,7 +136,7 @@ func TestLoadEnvAndSettings(t *testing.T) {
 	s, err := settings.New(logger, v, cmd, "")
 	require.NoError(t, err)
 	assert.Equal(t, "staging", s.User.TargetName)
-	assert.Equal(t, "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80", s.User.EthPrivateKey)
+	assert.Equal(t, "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80", s.User.PrivateKey(settings.EVM))
 }
 
 func TestLoadEnvAndSettingsWithWorkflowSettingsFlag(t *testing.T) {
@@ -169,7 +169,7 @@ func TestLoadEnvAndSettingsWithWorkflowSettingsFlag(t *testing.T) {
 	s, err := settings.New(logger, v, cmd, "")
 	require.NoError(t, err)
 	assert.Equal(t, "staging", s.User.TargetName)
-	assert.Equal(t, "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80", s.User.EthPrivateKey)
+	assert.Equal(t, "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80", s.User.PrivateKey(settings.EVM))
 }
 
 func TestInlineEnvTakesPrecedenceOverDotEnv(t *testing.T) {
@@ -199,7 +199,7 @@ func TestInlineEnvTakesPrecedenceOverDotEnv(t *testing.T) {
 	s, err := settings.New(logger, v, cmd, "")
 	require.NoError(t, err)
 	assert.Equal(t, "staging", s.User.TargetName)
-	assert.Equal(t, "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80", s.User.EthPrivateKey)
+	assert.Equal(t, "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80", s.User.PrivateKey(settings.EVM))
 }
 
 func TestLoadEnvAndMergedSettings(t *testing.T) {
@@ -241,7 +241,7 @@ func TestLoadEnvAndMergedSettings(t *testing.T) {
 	rpc2 := s.Workflow.RPCs[1]
 	assert.Equal(t, "https://somethingElse.rpc.org", rpc1.Url, "First RPC URL mismatch")
 	assert.Equal(t, "https://something.rpc.org", rpc2.Url, "Second RPC URL mismatch")
-	assert.Equal(t, "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80", s.User.EthPrivateKey)
+	assert.Equal(t, "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80", s.User.PrivateKey(settings.EVM))
 }
 
 // helper to build a command with optional --broadcast flag and parse args
@@ -330,7 +330,7 @@ func TestOffChainDeploymentRegistryUsesDerivedOwnerWithoutPrivateKey(t *testing.
 	require.NoError(t, err)
 	assert.Equal(t, derived, s.Workflow.UserWorkflowSettings.WorkflowOwnerAddress)
 	assert.Equal(t, constants.WorkflowOwnerTypeOrgDerived, s.Workflow.UserWorkflowSettings.WorkflowOwnerType)
-	assert.Empty(t, s.User.EthPrivateKey)
+	assert.Empty(t, s.User.PrivateKey(settings.EVM))
 }
 
 func TestOffChainDeploymentRegistryMissingDerivedOwnerReturnsError(t *testing.T) {

--- a/internal/settings/template/project.yaml.tpl
+++ b/internal/settings/template/project.yaml.tpl
@@ -26,7 +26,7 @@
 # In your workflow, reference the chain as <chain-type>:ChainSelector:<chain-selector>@1.0.0
 #
 #   experimental-chains:
-#     - chain-type: evm                             # "evm" (default) or "aptos"
+#     - chain-type: evm                             # Chain family
 #       chain-selector: 12345                       # The chain selector value
 #       rpc-url: "https://rpc.example.com"          # RPC endpoint URL
 #       forwarder: "0x..."                          # Forwarder contract address on the chain

--- a/test/multi_command_flows/workflow_private_registry.go
+++ b/test/multi_command_flows/workflow_private_registry.go
@@ -883,7 +883,7 @@ func RunPrivateRegistryAuthAndSettingsFinalize(t *testing.T, envPath, blankWorkf
 	s, err := settings.New(logger, v, cmd, "")
 	require.NoError(t, err)
 	require.NotNil(t, s)
-	require.Empty(t, s.User.EthPrivateKey, "CRE_ETH_PRIVATE_KEY must be absent")
+	require.Empty(t, s.User.PrivateKey(settings.EVM), "CRE_ETH_PRIVATE_KEY must be absent")
 	require.Equal(t, "reg-test", s.Workflow.UserWorkflowSettings.DeploymentRegistry)
 	require.Empty(t, s.Workflow.UserWorkflowSettings.WorkflowOwnerAddress, "owner is deferred until finalize when deployment-registry is set")
 	require.Empty(t, s.Workflow.UserWorkflowSettings.WorkflowOwnerType)


### PR DESCRIPTION
Replace EthPrivateKey / AptosPrivateKey fields on UserSettings with a single PrivateKeys map keyed by ChainType.Name, and introduce a ChainType struct that bundles each family's name + signing-key env var. Names are derived from corekeys.EVM / corekeys.Aptos so the canonical upstream identifiers are the single source of truth.

Adding a new chain family is now one entry in AllChainTypes instead of a new field, constant, and loader branch. Remove unused EthUrl and simplify the project.yaml experimental-chains example comment.