### PR TITLE
Simulator empty log message check

### DIFF
--- a/cmd/workflow/simulate/telemetry_writer.go
+++ b/cmd/workflow/simulate/telemetry_writer.go
@@ -253,6 +253,16 @@ func (w *telemetryWriter) handleCapabilityEvent(telLog TelemetryLog, eventType s
 	}
 }
 
+// trailingNewlines returns the number of consecutive "\n" characters at the
+// end of s.
+func trailingNewlines(s string) int {
+	n := 0
+	for i := len(s) - 1; i >= 0 && s[i] == '\n'; i-- {
+		n++
+	}
+	return n
+}
+
 // formatUserLogs formats and displays user logs in a readable way
 func (w *telemetryWriter) formatUserLogs(logs *pb.UserLogs) {
 	// Display each log line
@@ -269,8 +279,12 @@ func (w *telemetryWriter) formatUserLogs(logs *pb.UserLogs) {
 
 		// Whitespace-only payloads (e.g. runtime.log("\n")) render as actual
 		// blank line(s) so users can add visual spacing between log sections.
+		// Only count *trailing* newlines: counting every "\n" in the message
+		// would over-emit blank lines for content like
+		// "this is \n my error \n details \n more \n" (4 newlines, but the
+		// user only intends 1 blank line of trailing spacing).
 		if strings.TrimSpace(logLine.Message) == "" {
-			n := strings.Count(logLine.Message, "\n")
+			n := trailingNewlines(logLine.Message)
 			if n == 0 {
 				n = 1
 			}

--- a/cmd/workflow/simulate/telemetry_writer.go
+++ b/cmd/workflow/simulate/telemetry_writer.go
@@ -256,6 +256,16 @@ func (w *telemetryWriter) handleCapabilityEvent(telLog TelemetryLog, eventType s
 func (w *telemetryWriter) formatUserLogs(logs *pb.UserLogs) {
 	// Display each log line
 	for _, logLine := range logs.LogLines {
+		if logLine.Message == "" {
+			w.simLogger.PrintTimestampedLog(
+				time.Now().Format("2006-01-02T15:04:05Z"),
+				"USER LOG",
+				StyleRed.Render(`empty message payload not allowed; use "\n" within a message for formatting`),
+				StyleRed,
+			)
+			continue
+		}
+
 		// Format the log message
 		level := GetLogLevel(logLine.Message)
 		msg := CleanLogMessage(logLine.Message)

--- a/cmd/workflow/simulate/telemetry_writer.go
+++ b/cmd/workflow/simulate/telemetry_writer.go
@@ -3,6 +3,7 @@ package simulate
 import (
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"time"
 
@@ -263,6 +264,19 @@ func (w *telemetryWriter) formatUserLogs(logs *pb.UserLogs) {
 				StyleRed.Render(`empty message payload not allowed; use "\n" within a message for formatting`),
 				StyleRed,
 			)
+			continue
+		}
+
+		// Whitespace-only payloads (e.g. runtime.log("\n")) render as actual
+		// blank line(s) so users can add visual spacing between log sections.
+		if strings.TrimSpace(logLine.Message) == "" {
+			n := strings.Count(logLine.Message, "\n")
+			if n == 0 {
+				n = 1
+			}
+			for i := 0; i < n; i++ {
+				fmt.Println()
+			}
 			continue
 		}
 


### PR DESCRIPTION
# Summary

Display an error message `empty message payload not allowed; use "\n" within a message for formatting` when workflow has an empty `runtime.log()`. 