### PR TITLE
feat: add Registry field to workflow details header

### DIFF
--- a/cmd/workflow/activate/activate.go
+++ b/cmd/workflow/activate/activate.go
@@ -151,6 +151,7 @@ func (h *handler) resolveWorkflowOwner(registryType settings.RegistryType) (stri
 func (h *handler) displayWorkflowDetails() {
 	ui.Line()
 	ui.Title(fmt.Sprintf("Activating Workflow: %s", h.inputs.WorkflowName))
+	ui.Dim(fmt.Sprintf("Registry:      %s", h.runtimeContext.ResolvedRegistry.ID()))
 	ui.Dim(fmt.Sprintf("Target:        %s", h.settings.User.TargetName))
 	ui.Dim(fmt.Sprintf("Owner Address: %s", h.inputs.WorkflowOwner))
 	ui.Line()

--- a/cmd/workflow/activate/activate.go
+++ b/cmd/workflow/activate/activate.go
@@ -154,4 +154,3 @@ func (h *handler) resolveWorkflowOwner(registryType settings.RegistryType) (stri
 
 	return owner, nil
 }
-

--- a/cmd/workflow/activate/activate.go
+++ b/cmd/workflow/activate/activate.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/smartcontractkit/cre-cli/cmd/client"
+	workflowcommon "github.com/smartcontractkit/cre-cli/cmd/workflow/common"
 	"github.com/smartcontractkit/cre-cli/internal/environments"
 	"github.com/smartcontractkit/cre-cli/internal/runtime"
 	"github.com/smartcontractkit/cre-cli/internal/settings"
@@ -122,7 +123,13 @@ func (h *handler) Execute() error {
 		return fmt.Errorf("missing required flags for --non-interactive mode")
 	}
 
-	h.displayWorkflowDetails()
+	workflowcommon.DisplayWorkflowDetails(
+		h.settings,
+		h.runtimeContext,
+		"Activating",
+		h.inputs.WorkflowName,
+		h.inputs.WorkflowOwner,
+	)
 
 	strategy, err := newRegistryActivateStrategy(h.runtimeContext.ResolvedRegistry, h)
 	if err != nil {
@@ -148,11 +155,3 @@ func (h *handler) resolveWorkflowOwner(registryType settings.RegistryType) (stri
 	return owner, nil
 }
 
-func (h *handler) displayWorkflowDetails() {
-	ui.Line()
-	ui.Title(fmt.Sprintf("Activating Workflow: %s", h.inputs.WorkflowName))
-	ui.Dim(fmt.Sprintf("Registry:      %s", h.runtimeContext.ResolvedRegistry.ID()))
-	ui.Dim(fmt.Sprintf("Target:        %s", h.settings.User.TargetName))
-	ui.Dim(fmt.Sprintf("Owner Address: %s", h.inputs.WorkflowOwner))
-	ui.Line()
-}

--- a/cmd/workflow/common/display_workflow_details.go
+++ b/cmd/workflow/common/display_workflow_details.go
@@ -1,0 +1,29 @@
+package common
+
+import (
+	"fmt"
+
+	"github.com/smartcontractkit/cre-cli/internal/runtime"
+	"github.com/smartcontractkit/cre-cli/internal/settings"
+	"github.com/smartcontractkit/cre-cli/internal/ui"
+)
+
+func DisplayWorkflowDetails(
+	cfg *settings.Settings,
+	runtimeContext *runtime.Context,
+	action,
+	workflowName,
+	ownerAddress string,
+) {
+	displayOwnerAddress := ownerAddress
+	if runtimeContext.ResolvedRegistry.Type() == settings.RegistryTypeOffChain {
+		displayOwnerAddress += " (derived)"
+	}
+
+	ui.Line()
+	ui.Title(fmt.Sprintf("%s Workflow: %s", action, workflowName))
+	ui.Dim(fmt.Sprintf("Registry:      %s", runtimeContext.ResolvedRegistry.ID()))
+	ui.Dim(fmt.Sprintf("Target:        %s", cfg.User.TargetName))
+	ui.Dim(fmt.Sprintf("Owner Address: %s", displayOwnerAddress))
+	ui.Line()
+}

--- a/cmd/workflow/delete/delete.go
+++ b/cmd/workflow/delete/delete.go
@@ -216,6 +216,7 @@ func (h *handler) askForWorkflowDeletionConfirmation(expectedWorkflowName string
 func (h *handler) displayWorkflowDetails() {
 	ui.Line()
 	ui.Title(fmt.Sprintf("Deleting Workflow: %s", h.inputs.WorkflowName))
+	ui.Dim(fmt.Sprintf("Registry:      %s", h.runtimeContext.ResolvedRegistry.ID()))
 	ui.Dim(fmt.Sprintf("Target:        %s", h.settings.User.TargetName))
 	ui.Dim(fmt.Sprintf("Owner Address: %s", h.inputs.WorkflowOwner))
 	ui.Line()

--- a/cmd/workflow/delete/delete.go
+++ b/cmd/workflow/delete/delete.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/smartcontractkit/cre-cli/cmd/client"
+	workflowcommon "github.com/smartcontractkit/cre-cli/cmd/workflow/common"
 	"github.com/smartcontractkit/cre-cli/internal/credentials"
 	"github.com/smartcontractkit/cre-cli/internal/environments"
 	"github.com/smartcontractkit/cre-cli/internal/runtime"
@@ -133,7 +134,13 @@ func (h *handler) Execute() error {
 		return err
 	}
 
-	h.displayWorkflowDetails()
+	workflowcommon.DisplayWorkflowDetails(
+		h.settings,
+		h.runtimeContext,
+		"Deleting",
+		h.inputs.WorkflowName,
+		h.inputs.WorkflowOwner,
+	)
 
 	workflows, err := adapter.FetchWorkflows()
 	if err != nil {
@@ -211,13 +218,4 @@ func (h *handler) askForWorkflowDeletionConfirmation(expectedWorkflowName string
 	}
 
 	return result == expectedWorkflowName, nil
-}
-
-func (h *handler) displayWorkflowDetails() {
-	ui.Line()
-	ui.Title(fmt.Sprintf("Deleting Workflow: %s", h.inputs.WorkflowName))
-	ui.Dim(fmt.Sprintf("Registry:      %s", h.runtimeContext.ResolvedRegistry.ID()))
-	ui.Dim(fmt.Sprintf("Target:        %s", h.settings.User.TargetName))
-	ui.Dim(fmt.Sprintf("Owner Address: %s", h.inputs.WorkflowOwner))
-	ui.Line()
 }

--- a/cmd/workflow/deploy/deploy.go
+++ b/cmd/workflow/deploy/deploy.go
@@ -324,6 +324,7 @@ func (h *handler) resolveWorkflowOwner(registryType settings.RegistryType) (stri
 func (h *handler) displayWorkflowDetails() {
 	ui.Line()
 	ui.Title(fmt.Sprintf("Deploying Workflow: %s", h.inputs.WorkflowName))
+	ui.Dim(fmt.Sprintf("Registry:      %s", h.runtimeContext.ResolvedRegistry.ID()))
 	ui.Dim(fmt.Sprintf("Target:        %s", h.settings.User.TargetName))
 	ui.Dim(fmt.Sprintf("Owner Address: %s", h.inputs.WorkflowOwner))
 	ui.Line()

--- a/cmd/workflow/deploy/deploy.go
+++ b/cmd/workflow/deploy/deploy.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/smartcontractkit/cre-cli/cmd/client"
 	cmdcommon "github.com/smartcontractkit/cre-cli/cmd/common"
+	workflowcommon "github.com/smartcontractkit/cre-cli/cmd/workflow/common"
 	"github.com/smartcontractkit/cre-cli/internal/accessrequest"
 	"github.com/smartcontractkit/cre-cli/internal/credentials"
 	"github.com/smartcontractkit/cre-cli/internal/environments"
@@ -262,7 +263,13 @@ func (h *handler) Execute(ctx context.Context) error {
 // Artifact upload is deferred to the deploy service so it runs after any
 // existing-workflow update confirmation.
 func (h *handler) prepareArtifacts() error {
-	h.displayWorkflowDetails()
+	workflowcommon.DisplayWorkflowDetails(
+		h.settings,
+		h.runtimeContext,
+		"Deploying",
+		h.inputs.WorkflowName,
+		h.inputs.WorkflowOwner,
+	)
 
 	if cmdcommon.IsURL(h.inputs.WasmPath) {
 		h.inputs.BinaryURL = h.inputs.WasmPath
@@ -319,15 +326,6 @@ func (h *handler) resolveWorkflowOwner(registryType settings.RegistryType) (stri
 	}
 
 	return owner, nil
-}
-
-func (h *handler) displayWorkflowDetails() {
-	ui.Line()
-	ui.Title(fmt.Sprintf("Deploying Workflow: %s", h.inputs.WorkflowName))
-	ui.Dim(fmt.Sprintf("Registry:      %s", h.runtimeContext.ResolvedRegistry.ID()))
-	ui.Dim(fmt.Sprintf("Target:        %s", h.settings.User.TargetName))
-	ui.Dim(fmt.Sprintf("Owner Address: %s", h.inputs.WorkflowOwner))
-	ui.Line()
 }
 
 func confirmWorkflowOverwrite(workflowName string, skipConfirmation, nonInteractive bool) error {

--- a/cmd/workflow/pause/pause.go
+++ b/cmd/workflow/pause/pause.go
@@ -148,6 +148,7 @@ func (h *handler) resolveWorkflowOwner(registryType settings.RegistryType) (stri
 func (h *handler) displayWorkflowDetails() {
 	ui.Line()
 	ui.Title(fmt.Sprintf("Pausing Workflow: %s", h.inputs.WorkflowName))
+	ui.Dim(fmt.Sprintf("Registry:      %s", h.runtimeContext.ResolvedRegistry.ID()))
 	ui.Dim(fmt.Sprintf("Target:        %s", h.settings.User.TargetName))
 	ui.Dim(fmt.Sprintf("Owner Address: %s", h.inputs.WorkflowOwner))
 	ui.Line()

--- a/cmd/workflow/pause/pause.go
+++ b/cmd/workflow/pause/pause.go
@@ -151,4 +151,3 @@ func (h *handler) resolveWorkflowOwner(registryType settings.RegistryType) (stri
 
 	return owner, nil
 }
-

--- a/cmd/workflow/pause/pause.go
+++ b/cmd/workflow/pause/pause.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/smartcontractkit/cre-cli/cmd/client"
+	workflowcommon "github.com/smartcontractkit/cre-cli/cmd/workflow/common"
 	"github.com/smartcontractkit/cre-cli/internal/environments"
 	"github.com/smartcontractkit/cre-cli/internal/runtime"
 	"github.com/smartcontractkit/cre-cli/internal/settings"
@@ -119,7 +120,13 @@ func (h *handler) Execute() error {
 		return fmt.Errorf("missing required flags for --non-interactive mode")
 	}
 
-	h.displayWorkflowDetails()
+	workflowcommon.DisplayWorkflowDetails(
+		h.settings,
+		h.runtimeContext,
+		"Pausing",
+		h.inputs.WorkflowName,
+		h.inputs.WorkflowOwner,
+	)
 
 	strategy, err := newRegistryPauseStrategy(h.runtimeContext.ResolvedRegistry, h)
 	if err != nil {
@@ -145,11 +152,3 @@ func (h *handler) resolveWorkflowOwner(registryType settings.RegistryType) (stri
 	return owner, nil
 }
 
-func (h *handler) displayWorkflowDetails() {
-	ui.Line()
-	ui.Title(fmt.Sprintf("Pausing Workflow: %s", h.inputs.WorkflowName))
-	ui.Dim(fmt.Sprintf("Registry:      %s", h.runtimeContext.ResolvedRegistry.ID()))
-	ui.Dim(fmt.Sprintf("Target:        %s", h.settings.User.TargetName))
-	ui.Dim(fmt.Sprintf("Owner Address: %s", h.inputs.WorkflowOwner))
-	ui.Line()
-}

--- a/internal/settings/registry_resolution.go
+++ b/internal/settings/registry_resolution.go
@@ -127,7 +127,7 @@ func ParseRegistryType(raw string) RegistryType {
 
 func defaultFromEnvironmentSet(envSet *environments.EnvironmentSet) *OnChainRegistry {
 	return NewOnChainRegistry(
-		"",
+		fmt.Sprintf("onchain:%s", envSet.WorkflowRegistryChainName),
 		envSet.WorkflowRegistryAddress,
 		envSet.WorkflowRegistryChainName,
 		envSet.DonFamily,


### PR DESCRIPTION
[DEVSVCS-4926](https://smartcontract-it.atlassian.net/browse/DEVSVCS-4926)

This pull request refactors the workflow commands (`activate`, `delete`, `deploy`, and `pause`) to use a shared function for displaying workflow details, improving code reuse and consistency across commands. The display logic is now centralized in a new `DisplayWorkflowDetails` function under `cmd/workflow/common`. Additionally, the registry ID for on-chain registries is now more descriptive.

### Improvements

* Introduced a new `DisplayWorkflowDetails` function in `cmd/workflow/common/display_workflow_details.go` to standardize and centralize the display of workflow details across commands. This function also annotates off-chain owner addresses as "(derived)".
* Add Registry field to display - displays ID of the registry selected.
* Updated `activate.go`, `delete.go`, `deploy.go`, and `pause.go` to use the new `DisplayWorkflowDetails` function instead of their own local `displayWorkflowDetails` methods. Removed the now-redundant local display methods from each command. [[1]](diffhunk://#diff-a015a8fa24d2072da521c2fa63cc0afe7acec265e1af1dd0bbd45b5836715f11R11) [[2]](diffhunk://#diff-a015a8fa24d2072da521c2fa63cc0afe7acec265e1af1dd0bbd45b5836715f11L125-R132) [[3]](diffhunk://#diff-a015a8fa24d2072da521c2fa63cc0afe7acec265e1af1dd0bbd45b5836715f11L151-L157) [[4]](diffhunk://#diff-01db0c5361969b5b259bbfea22b441906e3c6533ec30515c1b08f0665b12a9b3R12) [[5]](diffhunk://#diff-01db0c5361969b5b259bbfea22b441906e3c6533ec30515c1b08f0665b12a9b3L136-R143) [[6]](diffhunk://#diff-01db0c5361969b5b259bbfea22b441906e3c6533ec30515c1b08f0665b12a9b3L215-L222) [[7]](diffhunk://#diff-d1a6bd049fc7708585314679c14001a13654e07880e5a9b2419b883f4d88c21fR15) [[8]](diffhunk://#diff-d1a6bd049fc7708585314679c14001a13654e07880e5a9b2419b883f4d88c21fL265-R272) [[9]](diffhunk://#diff-d1a6bd049fc7708585314679c14001a13654e07880e5a9b2419b883f4d88c21fL324-L331) [[10]](diffhunk://#diff-b6698cc4fd33149bdbdeb7cc12cb38751a150a5bcbfdc6cb1f908a5a45e74850R11) [[11]](diffhunk://#diff-b6698cc4fd33149bdbdeb7cc12cb38751a150a5bcbfdc6cb1f908a5a45e74850L122-R129) [[12]](diffhunk://#diff-b6698cc4fd33149bdbdeb7cc12cb38751a150a5bcbfdc6cb1f908a5a45e74850L148-L154)

### Registry ID improvement:

* Changed the default registry ID for on-chain registries to include the chain name (e.g., `onchain:<chainName>`) for better clarity in logs and UI.