### PR TITLE
Document deployment-registry usage in cre registry list

### DIFF
--- a/cmd/registry/list/list.go
+++ b/cmd/registry/list/list.go
@@ -11,9 +11,17 @@ import (
 
 func New(runtimeContext *runtime.Context) *cobra.Command {
 	return &cobra.Command{
-		Use:     "list",
-		Short:   "Lists available workflow registries for the current environment",
-		Long:    `Displays the registries configured for your organization, including type and address.`,
+		Use:   "list",
+		Short: "Lists available workflow registries for the current environment",
+		Long: `Displays the registries configured for your organization, including type and address.
+
+The ID shown for each registry is the value you set in workflow.yaml
+under the ` + "`deployment-registry`" + ` key to target that registry, e.g.:
+
+  <target-name>:
+    user-workflow:
+      workflow-name: "my-workflow"
+      deployment-registry: "private"`,
 		Example: `cre registry list`,
 		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -40,6 +48,14 @@ func New(runtimeContext *runtime.Context) *cobra.Command {
 				}
 				ui.Line()
 			}
+
+			ui.Bold("Targeting a registry")
+			ui.Dim("Set `deployment-registry` in your workflow.yaml to one of the IDs above:")
+			ui.Line()
+			ui.Code("  <target-name>:")
+			ui.Code("    user-workflow:")
+			ui.Code("      deployment-registry: \"private\"")
+			ui.Line()
 
 			return nil
 		},

--- a/cmd/registry/list/list.go
+++ b/cmd/registry/list/list.go
@@ -54,7 +54,7 @@ under the ` + "`deployment-registry`" + ` key to target that registry, e.g.:
 			ui.Line()
 			ui.Code("  <target-name>:")
 			ui.Code("    user-workflow:")
-			ui.Code("      deployment-registry: \"private\"")
+			ui.Code(fmt.Sprintf("      deployment-registry: %q", registries[0].ID))
 			ui.Line()
 
 			return nil

--- a/docs/cre_registry_list.md
+++ b/docs/cre_registry_list.md
@@ -6,6 +6,14 @@ Lists available workflow registries for the current environment
 
 Displays the registries configured for your organization, including type and address.
 
+The ID shown for each registry is the value you set in workflow.yaml
+under the `deployment-registry` key to target that registry, e.g.:
+
+  <target-name>:
+    user-workflow:
+      workflow-name: "my-workflow"
+      deployment-registry: "private"
+
 ```
 cre registry list [optional flags]
 ```


### PR DESCRIPTION
# Summary                                                                                                                                                                                                                                             
  - cre registry list --help now explains that the displayed ID is the value to set as deployment-registry in workflow.yaml, with a yaml snippet.
  - The command output appends a "Targeting a registry" hint pointing users to set deployment-registry to one of the listed IDs.      