### PR TITLE
Non-evms supported-chains list & --allow-unknown-chains flag

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -415,6 +415,16 @@ func newRootCommand() *cobra.Command {
 		false,
 		"Fail instead of prompting; requires all inputs via flags",
 	)
+	// allow-unknown-chains skips chain-name validation against the chain-selectors
+	// registry so experimental chains can be configured and tested before they are
+	// added upstream. The chain name is still passed through verbatim to RPC and
+	// selector lookups, which will surface their own errors if the chain is truly
+	// unknown to downstream callers.
+	rootCmd.PersistentFlags().Bool(
+		settings.Flags.AllowUnknownChains.Name,
+		false,
+		"Skip chain-name validation against the chain-selectors registry (for experimental chains)",
+	)
 	rootCmd.CompletionOptions.HiddenDefaultCmd = true
 
 	secretsCmd := secrets.New(runtimeContext)

--- a/docs/cre.md
+++ b/docs/cre.md
@@ -13,13 +13,14 @@ cre [optional flags]
 ### Options
 
 ```
-  -e, --env string            Path to .env file which contains sensitive info
-  -h, --help                  help for cre
-      --non-interactive       Fail instead of prompting; requires all inputs via flags
-  -R, --project-root string   Path to the project root
-  -E, --public-env string     Path to .env.public file which contains shared, non-sensitive build config
-  -T, --target string         Use target settings from YAML config
-  -v, --verbose               Run command in VERBOSE mode
+      --allow-unknown-chains   Skip chain-name validation against the chain-selectors registry (for experimental chains)
+  -e, --env string             Path to .env file which contains sensitive info
+  -h, --help                   help for cre
+      --non-interactive        Fail instead of prompting; requires all inputs via flags
+  -R, --project-root string    Path to the project root
+  -E, --public-env string      Path to .env.public file which contains shared, non-sensitive build config
+  -T, --target string          Use target settings from YAML config
+  -v, --verbose                Run command in VERBOSE mode
 ```
 
 ### SEE ALSO

--- a/docs/cre_account.md
+++ b/docs/cre_account.md
@@ -19,12 +19,13 @@ cre account [optional flags]
 ### Options inherited from parent commands
 
 ```
-  -e, --env string            Path to .env file which contains sensitive info
-      --non-interactive       Fail instead of prompting; requires all inputs via flags
-  -R, --project-root string   Path to the project root
-  -E, --public-env string     Path to .env.public file which contains shared, non-sensitive build config
-  -T, --target string         Use target settings from YAML config
-  -v, --verbose               Run command in VERBOSE mode
+      --allow-unknown-chains   Skip chain-name validation against the chain-selectors registry (for experimental chains)
+  -e, --env string             Path to .env file which contains sensitive info
+      --non-interactive        Fail instead of prompting; requires all inputs via flags
+  -R, --project-root string    Path to the project root
+  -E, --public-env string      Path to .env.public file which contains shared, non-sensitive build config
+  -T, --target string          Use target settings from YAML config
+  -v, --verbose                Run command in VERBOSE mode
 ```
 
 ### SEE ALSO

--- a/docs/cre_account_access.md
+++ b/docs/cre_account_access.md
@@ -19,12 +19,13 @@ cre account access [optional flags]
 ### Options inherited from parent commands
 
 ```
-  -e, --env string            Path to .env file which contains sensitive info
-      --non-interactive       Fail instead of prompting; requires all inputs via flags
-  -R, --project-root string   Path to the project root
-  -E, --public-env string     Path to .env.public file which contains shared, non-sensitive build config
-  -T, --target string         Use target settings from YAML config
-  -v, --verbose               Run command in VERBOSE mode
+      --allow-unknown-chains   Skip chain-name validation against the chain-selectors registry (for experimental chains)
+  -e, --env string             Path to .env file which contains sensitive info
+      --non-interactive        Fail instead of prompting; requires all inputs via flags
+  -R, --project-root string    Path to the project root
+  -E, --public-env string      Path to .env.public file which contains shared, non-sensitive build config
+  -T, --target string          Use target settings from YAML config
+  -v, --verbose                Run command in VERBOSE mode
 ```
 
 ### SEE ALSO

--- a/docs/cre_account_link-key.md
+++ b/docs/cre_account_link-key.md
@@ -22,12 +22,13 @@ cre account link-key [optional flags]
 ### Options inherited from parent commands
 
 ```
-  -e, --env string            Path to .env file which contains sensitive info
-      --non-interactive       Fail instead of prompting; requires all inputs via flags
-  -R, --project-root string   Path to the project root
-  -E, --public-env string     Path to .env.public file which contains shared, non-sensitive build config
-  -T, --target string         Use target settings from YAML config
-  -v, --verbose               Run command in VERBOSE mode
+      --allow-unknown-chains   Skip chain-name validation against the chain-selectors registry (for experimental chains)
+  -e, --env string             Path to .env file which contains sensitive info
+      --non-interactive        Fail instead of prompting; requires all inputs via flags
+  -R, --project-root string    Path to the project root
+  -E, --public-env string      Path to .env.public file which contains shared, non-sensitive build config
+  -T, --target string          Use target settings from YAML config
+  -v, --verbose                Run command in VERBOSE mode
 ```
 
 ### SEE ALSO

--- a/docs/cre_account_list-key.md
+++ b/docs/cre_account_list-key.md
@@ -19,12 +19,13 @@ cre account list-key [optional flags]
 ### Options inherited from parent commands
 
 ```
-  -e, --env string            Path to .env file which contains sensitive info
-      --non-interactive       Fail instead of prompting; requires all inputs via flags
-  -R, --project-root string   Path to the project root
-  -E, --public-env string     Path to .env.public file which contains shared, non-sensitive build config
-  -T, --target string         Use target settings from YAML config
-  -v, --verbose               Run command in VERBOSE mode
+      --allow-unknown-chains   Skip chain-name validation against the chain-selectors registry (for experimental chains)
+  -e, --env string             Path to .env file which contains sensitive info
+      --non-interactive        Fail instead of prompting; requires all inputs via flags
+  -R, --project-root string    Path to the project root
+  -E, --public-env string      Path to .env.public file which contains shared, non-sensitive build config
+  -T, --target string          Use target settings from YAML config
+  -v, --verbose                Run command in VERBOSE mode
 ```
 
 ### SEE ALSO

--- a/docs/cre_account_unlink-key.md
+++ b/docs/cre_account_unlink-key.md
@@ -21,12 +21,13 @@ cre account unlink-key [optional flags]
 ### Options inherited from parent commands
 
 ```
-  -e, --env string            Path to .env file which contains sensitive info
-      --non-interactive       Fail instead of prompting; requires all inputs via flags
-  -R, --project-root string   Path to the project root
-  -E, --public-env string     Path to .env.public file which contains shared, non-sensitive build config
-  -T, --target string         Use target settings from YAML config
-  -v, --verbose               Run command in VERBOSE mode
+      --allow-unknown-chains   Skip chain-name validation against the chain-selectors registry (for experimental chains)
+  -e, --env string             Path to .env file which contains sensitive info
+      --non-interactive        Fail instead of prompting; requires all inputs via flags
+  -R, --project-root string    Path to the project root
+  -E, --public-env string      Path to .env.public file which contains shared, non-sensitive build config
+  -T, --target string          Use target settings from YAML config
+  -v, --verbose                Run command in VERBOSE mode
 ```
 
 ### SEE ALSO

--- a/docs/cre_generate-bindings.md
+++ b/docs/cre_generate-bindings.md
@@ -37,11 +37,12 @@ cre generate-bindings <chain-family> [optional flags]
 ### Options inherited from parent commands
 
 ```
-  -e, --env string          Path to .env file which contains sensitive info
-      --non-interactive     Fail instead of prompting; requires all inputs via flags
-  -E, --public-env string   Path to .env.public file which contains shared, non-sensitive build config
-  -T, --target string       Use target settings from YAML config
-  -v, --verbose             Run command in VERBOSE mode
+      --allow-unknown-chains   Skip chain-name validation against the chain-selectors registry (for experimental chains)
+  -e, --env string             Path to .env file which contains sensitive info
+      --non-interactive        Fail instead of prompting; requires all inputs via flags
+  -E, --public-env string      Path to .env.public file which contains shared, non-sensitive build config
+  -T, --target string          Use target settings from YAML config
+  -v, --verbose                Run command in VERBOSE mode
 ```
 
 ### SEE ALSO

--- a/docs/cre_init.md
+++ b/docs/cre_init.md
@@ -29,12 +29,13 @@ cre init [optional flags]
 ### Options inherited from parent commands
 
 ```
-  -e, --env string            Path to .env file which contains sensitive info
-      --non-interactive       Fail instead of prompting; requires all inputs via flags
-  -R, --project-root string   Path to the project root
-  -E, --public-env string     Path to .env.public file which contains shared, non-sensitive build config
-  -T, --target string         Use target settings from YAML config
-  -v, --verbose               Run command in VERBOSE mode
+      --allow-unknown-chains   Skip chain-name validation against the chain-selectors registry (for experimental chains)
+  -e, --env string             Path to .env file which contains sensitive info
+      --non-interactive        Fail instead of prompting; requires all inputs via flags
+  -R, --project-root string    Path to the project root
+  -E, --public-env string      Path to .env.public file which contains shared, non-sensitive build config
+  -T, --target string          Use target settings from YAML config
+  -v, --verbose                Run command in VERBOSE mode
 ```
 
 ### SEE ALSO

--- a/docs/cre_login.md
+++ b/docs/cre_login.md
@@ -28,12 +28,13 @@ cre login [optional flags]
 ### Options inherited from parent commands
 
 ```
-  -e, --env string            Path to .env file which contains sensitive info
-      --non-interactive       Fail instead of prompting; requires all inputs via flags
-  -R, --project-root string   Path to the project root
-  -E, --public-env string     Path to .env.public file which contains shared, non-sensitive build config
-  -T, --target string         Use target settings from YAML config
-  -v, --verbose               Run command in VERBOSE mode
+      --allow-unknown-chains   Skip chain-name validation against the chain-selectors registry (for experimental chains)
+  -e, --env string             Path to .env file which contains sensitive info
+      --non-interactive        Fail instead of prompting; requires all inputs via flags
+  -R, --project-root string    Path to the project root
+  -E, --public-env string      Path to .env.public file which contains shared, non-sensitive build config
+  -T, --target string          Use target settings from YAML config
+  -v, --verbose                Run command in VERBOSE mode
 ```
 
 ### SEE ALSO

--- a/docs/cre_logout.md
+++ b/docs/cre_logout.md
@@ -19,12 +19,13 @@ cre logout [optional flags]
 ### Options inherited from parent commands
 
 ```
-  -e, --env string            Path to .env file which contains sensitive info
-      --non-interactive       Fail instead of prompting; requires all inputs via flags
-  -R, --project-root string   Path to the project root
-  -E, --public-env string     Path to .env.public file which contains shared, non-sensitive build config
-  -T, --target string         Use target settings from YAML config
-  -v, --verbose               Run command in VERBOSE mode
+      --allow-unknown-chains   Skip chain-name validation against the chain-selectors registry (for experimental chains)
+  -e, --env string             Path to .env file which contains sensitive info
+      --non-interactive        Fail instead of prompting; requires all inputs via flags
+  -R, --project-root string    Path to the project root
+  -E, --public-env string      Path to .env.public file which contains shared, non-sensitive build config
+  -T, --target string          Use target settings from YAML config
+  -v, --verbose                Run command in VERBOSE mode
 ```
 
 ### SEE ALSO

--- a/docs/cre_registry.md
+++ b/docs/cre_registry.md
@@ -19,12 +19,13 @@ cre registry [optional flags]
 ### Options inherited from parent commands
 
 ```
-  -e, --env string            Path to .env file which contains sensitive info
-      --non-interactive       Fail instead of prompting; requires all inputs via flags
-  -R, --project-root string   Path to the project root
-  -E, --public-env string     Path to .env.public file which contains shared, non-sensitive build config
-  -T, --target string         Use target settings from YAML config
-  -v, --verbose               Run command in VERBOSE mode
+      --allow-unknown-chains   Skip chain-name validation against the chain-selectors registry (for experimental chains)
+  -e, --env string             Path to .env file which contains sensitive info
+      --non-interactive        Fail instead of prompting; requires all inputs via flags
+  -R, --project-root string    Path to the project root
+  -E, --public-env string      Path to .env.public file which contains shared, non-sensitive build config
+  -T, --target string          Use target settings from YAML config
+  -v, --verbose                Run command in VERBOSE mode
 ```
 
 ### SEE ALSO

--- a/docs/cre_registry_list.md
+++ b/docs/cre_registry_list.md
@@ -33,12 +33,13 @@ cre registry list
 ### Options inherited from parent commands
 
 ```
-  -e, --env string            Path to .env file which contains sensitive info
-      --non-interactive       Fail instead of prompting; requires all inputs via flags
-  -R, --project-root string   Path to the project root
-  -E, --public-env string     Path to .env.public file which contains shared, non-sensitive build config
-  -T, --target string         Use target settings from YAML config
-  -v, --verbose               Run command in VERBOSE mode
+      --allow-unknown-chains   Skip chain-name validation against the chain-selectors registry (for experimental chains)
+  -e, --env string             Path to .env file which contains sensitive info
+      --non-interactive        Fail instead of prompting; requires all inputs via flags
+  -R, --project-root string    Path to the project root
+  -E, --public-env string      Path to .env.public file which contains shared, non-sensitive build config
+  -T, --target string          Use target settings from YAML config
+  -v, --verbose                Run command in VERBOSE mode
 ```
 
 ### SEE ALSO

--- a/docs/cre_secrets.md
+++ b/docs/cre_secrets.md
@@ -20,12 +20,13 @@ cre secrets [optional flags]
 ### Options inherited from parent commands
 
 ```
-  -e, --env string            Path to .env file which contains sensitive info
-      --non-interactive       Fail instead of prompting; requires all inputs via flags
-  -R, --project-root string   Path to the project root
-  -E, --public-env string     Path to .env.public file which contains shared, non-sensitive build config
-  -T, --target string         Use target settings from YAML config
-  -v, --verbose               Run command in VERBOSE mode
+      --allow-unknown-chains   Skip chain-name validation against the chain-selectors registry (for experimental chains)
+  -e, --env string             Path to .env file which contains sensitive info
+      --non-interactive        Fail instead of prompting; requires all inputs via flags
+  -R, --project-root string    Path to the project root
+  -E, --public-env string      Path to .env.public file which contains shared, non-sensitive build config
+  -T, --target string          Use target settings from YAML config
+  -v, --verbose                Run command in VERBOSE mode
 ```
 
 ### SEE ALSO

--- a/docs/cre_secrets_create.md
+++ b/docs/cre_secrets_create.md
@@ -23,13 +23,14 @@ cre secrets create my-secrets.yaml
 ### Options inherited from parent commands
 
 ```
-  -e, --env string            Path to .env file which contains sensitive info
-      --non-interactive       Fail instead of prompting; requires all inputs via flags
-  -R, --project-root string   Path to the project root
-  -E, --public-env string     Path to .env.public file which contains shared, non-sensitive build config
-  -T, --target string         Use target settings from YAML config
-      --timeout duration      Timeout for secrets operations (e.g. 30m, 2h, 48h). (default 48h0m0s)
-  -v, --verbose               Run command in VERBOSE mode
+      --allow-unknown-chains   Skip chain-name validation against the chain-selectors registry (for experimental chains)
+  -e, --env string             Path to .env file which contains sensitive info
+      --non-interactive        Fail instead of prompting; requires all inputs via flags
+  -R, --project-root string    Path to the project root
+  -E, --public-env string      Path to .env.public file which contains shared, non-sensitive build config
+  -T, --target string          Use target settings from YAML config
+      --timeout duration       Timeout for secrets operations (e.g. 30m, 2h, 48h). (default 48h0m0s)
+  -v, --verbose                Run command in VERBOSE mode
 ```
 
 ### SEE ALSO

--- a/docs/cre_secrets_delete.md
+++ b/docs/cre_secrets_delete.md
@@ -23,13 +23,14 @@ cre secrets delete my-secrets.yaml
 ### Options inherited from parent commands
 
 ```
-  -e, --env string            Path to .env file which contains sensitive info
-      --non-interactive       Fail instead of prompting; requires all inputs via flags
-  -R, --project-root string   Path to the project root
-  -E, --public-env string     Path to .env.public file which contains shared, non-sensitive build config
-  -T, --target string         Use target settings from YAML config
-      --timeout duration      Timeout for secrets operations (e.g. 30m, 2h, 48h). (default 48h0m0s)
-  -v, --verbose               Run command in VERBOSE mode
+      --allow-unknown-chains   Skip chain-name validation against the chain-selectors registry (for experimental chains)
+  -e, --env string             Path to .env file which contains sensitive info
+      --non-interactive        Fail instead of prompting; requires all inputs via flags
+  -R, --project-root string    Path to the project root
+  -E, --public-env string      Path to .env.public file which contains shared, non-sensitive build config
+  -T, --target string          Use target settings from YAML config
+      --timeout duration       Timeout for secrets operations (e.g. 30m, 2h, 48h). (default 48h0m0s)
+  -v, --verbose                Run command in VERBOSE mode
 ```
 
 ### SEE ALSO

--- a/docs/cre_secrets_execute.md
+++ b/docs/cre_secrets_execute.md
@@ -22,13 +22,14 @@ cre secrets execute 157364...af4d5.json
 ### Options inherited from parent commands
 
 ```
-  -e, --env string            Path to .env file which contains sensitive info
-      --non-interactive       Fail instead of prompting; requires all inputs via flags
-  -R, --project-root string   Path to the project root
-  -E, --public-env string     Path to .env.public file which contains shared, non-sensitive build config
-  -T, --target string         Use target settings from YAML config
-      --timeout duration      Timeout for secrets operations (e.g. 30m, 2h, 48h). (default 48h0m0s)
-  -v, --verbose               Run command in VERBOSE mode
+      --allow-unknown-chains   Skip chain-name validation against the chain-selectors registry (for experimental chains)
+  -e, --env string             Path to .env file which contains sensitive info
+      --non-interactive        Fail instead of prompting; requires all inputs via flags
+  -R, --project-root string    Path to the project root
+  -E, --public-env string      Path to .env.public file which contains shared, non-sensitive build config
+  -T, --target string          Use target settings from YAML config
+      --timeout duration       Timeout for secrets operations (e.g. 30m, 2h, 48h). (default 48h0m0s)
+  -v, --verbose                Run command in VERBOSE mode
 ```
 
 ### SEE ALSO

--- a/docs/cre_secrets_list.md
+++ b/docs/cre_secrets_list.md
@@ -18,13 +18,14 @@ cre secrets list [optional flags]
 ### Options inherited from parent commands
 
 ```
-  -e, --env string            Path to .env file which contains sensitive info
-      --non-interactive       Fail instead of prompting; requires all inputs via flags
-  -R, --project-root string   Path to the project root
-  -E, --public-env string     Path to .env.public file which contains shared, non-sensitive build config
-  -T, --target string         Use target settings from YAML config
-      --timeout duration      Timeout for secrets operations (e.g. 30m, 2h, 48h). (default 48h0m0s)
-  -v, --verbose               Run command in VERBOSE mode
+      --allow-unknown-chains   Skip chain-name validation against the chain-selectors registry (for experimental chains)
+  -e, --env string             Path to .env file which contains sensitive info
+      --non-interactive        Fail instead of prompting; requires all inputs via flags
+  -R, --project-root string    Path to the project root
+  -E, --public-env string      Path to .env.public file which contains shared, non-sensitive build config
+  -T, --target string          Use target settings from YAML config
+      --timeout duration       Timeout for secrets operations (e.g. 30m, 2h, 48h). (default 48h0m0s)
+  -v, --verbose                Run command in VERBOSE mode
 ```
 
 ### SEE ALSO

--- a/docs/cre_secrets_update.md
+++ b/docs/cre_secrets_update.md
@@ -23,13 +23,14 @@ cre secrets update my-secrets.yaml
 ### Options inherited from parent commands
 
 ```
-  -e, --env string            Path to .env file which contains sensitive info
-      --non-interactive       Fail instead of prompting; requires all inputs via flags
-  -R, --project-root string   Path to the project root
-  -E, --public-env string     Path to .env.public file which contains shared, non-sensitive build config
-  -T, --target string         Use target settings from YAML config
-      --timeout duration      Timeout for secrets operations (e.g. 30m, 2h, 48h). (default 48h0m0s)
-  -v, --verbose               Run command in VERBOSE mode
+      --allow-unknown-chains   Skip chain-name validation against the chain-selectors registry (for experimental chains)
+  -e, --env string             Path to .env file which contains sensitive info
+      --non-interactive        Fail instead of prompting; requires all inputs via flags
+  -R, --project-root string    Path to the project root
+  -E, --public-env string      Path to .env.public file which contains shared, non-sensitive build config
+  -T, --target string          Use target settings from YAML config
+      --timeout duration       Timeout for secrets operations (e.g. 30m, 2h, 48h). (default 48h0m0s)
+  -v, --verbose                Run command in VERBOSE mode
 ```
 
 ### SEE ALSO

--- a/docs/cre_templates.md
+++ b/docs/cre_templates.md
@@ -24,12 +24,13 @@ cre templates [optional flags]
 ### Options inherited from parent commands
 
 ```
-  -e, --env string            Path to .env file which contains sensitive info
-      --non-interactive       Fail instead of prompting; requires all inputs via flags
-  -R, --project-root string   Path to the project root
-  -E, --public-env string     Path to .env.public file which contains shared, non-sensitive build config
-  -T, --target string         Use target settings from YAML config
-  -v, --verbose               Run command in VERBOSE mode
+      --allow-unknown-chains   Skip chain-name validation against the chain-selectors registry (for experimental chains)
+  -e, --env string             Path to .env file which contains sensitive info
+      --non-interactive        Fail instead of prompting; requires all inputs via flags
+  -R, --project-root string    Path to the project root
+  -E, --public-env string      Path to .env.public file which contains shared, non-sensitive build config
+  -T, --target string          Use target settings from YAML config
+  -v, --verbose                Run command in VERBOSE mode
 ```
 
 ### SEE ALSO

--- a/docs/cre_templates_add.md
+++ b/docs/cre_templates_add.md
@@ -25,12 +25,13 @@ cre templates add smartcontractkit/cre-templates@main myorg/my-templates
 ### Options inherited from parent commands
 
 ```
-  -e, --env string            Path to .env file which contains sensitive info
-      --non-interactive       Fail instead of prompting; requires all inputs via flags
-  -R, --project-root string   Path to the project root
-  -E, --public-env string     Path to .env.public file which contains shared, non-sensitive build config
-  -T, --target string         Use target settings from YAML config
-  -v, --verbose               Run command in VERBOSE mode
+      --allow-unknown-chains   Skip chain-name validation against the chain-selectors registry (for experimental chains)
+  -e, --env string             Path to .env file which contains sensitive info
+      --non-interactive        Fail instead of prompting; requires all inputs via flags
+  -R, --project-root string    Path to the project root
+  -E, --public-env string      Path to .env.public file which contains shared, non-sensitive build config
+  -T, --target string          Use target settings from YAML config
+  -v, --verbose                Run command in VERBOSE mode
 ```
 
 ### SEE ALSO

--- a/docs/cre_templates_list.md
+++ b/docs/cre_templates_list.md
@@ -21,12 +21,13 @@ cre templates list [optional flags]
 ### Options inherited from parent commands
 
 ```
-  -e, --env string            Path to .env file which contains sensitive info
-      --non-interactive       Fail instead of prompting; requires all inputs via flags
-  -R, --project-root string   Path to the project root
-  -E, --public-env string     Path to .env.public file which contains shared, non-sensitive build config
-  -T, --target string         Use target settings from YAML config
-  -v, --verbose               Run command in VERBOSE mode
+      --allow-unknown-chains   Skip chain-name validation against the chain-selectors registry (for experimental chains)
+  -e, --env string             Path to .env file which contains sensitive info
+      --non-interactive        Fail instead of prompting; requires all inputs via flags
+  -R, --project-root string    Path to the project root
+  -E, --public-env string      Path to .env.public file which contains shared, non-sensitive build config
+  -T, --target string          Use target settings from YAML config
+  -v, --verbose                Run command in VERBOSE mode
 ```
 
 ### SEE ALSO

--- a/docs/cre_templates_remove.md
+++ b/docs/cre_templates_remove.md
@@ -25,12 +25,13 @@ cre templates remove smartcontractkit/cre-templates myorg/my-templates
 ### Options inherited from parent commands
 
 ```
-  -e, --env string            Path to .env file which contains sensitive info
-      --non-interactive       Fail instead of prompting; requires all inputs via flags
-  -R, --project-root string   Path to the project root
-  -E, --public-env string     Path to .env.public file which contains shared, non-sensitive build config
-  -T, --target string         Use target settings from YAML config
-  -v, --verbose               Run command in VERBOSE mode
+      --allow-unknown-chains   Skip chain-name validation against the chain-selectors registry (for experimental chains)
+  -e, --env string             Path to .env file which contains sensitive info
+      --non-interactive        Fail instead of prompting; requires all inputs via flags
+  -R, --project-root string    Path to the project root
+  -E, --public-env string      Path to .env.public file which contains shared, non-sensitive build config
+  -T, --target string          Use target settings from YAML config
+  -v, --verbose                Run command in VERBOSE mode
 ```
 
 ### SEE ALSO

--- a/docs/cre_update.md
+++ b/docs/cre_update.md
@@ -15,12 +15,13 @@ cre update [optional flags]
 ### Options inherited from parent commands
 
 ```
-  -e, --env string            Path to .env file which contains sensitive info
-      --non-interactive       Fail instead of prompting; requires all inputs via flags
-  -R, --project-root string   Path to the project root
-  -E, --public-env string     Path to .env.public file which contains shared, non-sensitive build config
-  -T, --target string         Use target settings from YAML config
-  -v, --verbose               Run command in VERBOSE mode
+      --allow-unknown-chains   Skip chain-name validation against the chain-selectors registry (for experimental chains)
+  -e, --env string             Path to .env file which contains sensitive info
+      --non-interactive        Fail instead of prompting; requires all inputs via flags
+  -R, --project-root string    Path to the project root
+  -E, --public-env string      Path to .env.public file which contains shared, non-sensitive build config
+  -T, --target string          Use target settings from YAML config
+  -v, --verbose                Run command in VERBOSE mode
 ```
 
 ### SEE ALSO

--- a/docs/cre_version.md
+++ b/docs/cre_version.md
@@ -19,12 +19,13 @@ cre version [optional flags]
 ### Options inherited from parent commands
 
 ```
-  -e, --env string            Path to .env file which contains sensitive info
-      --non-interactive       Fail instead of prompting; requires all inputs via flags
-  -R, --project-root string   Path to the project root
-  -E, --public-env string     Path to .env.public file which contains shared, non-sensitive build config
-  -T, --target string         Use target settings from YAML config
-  -v, --verbose               Run command in VERBOSE mode
+      --allow-unknown-chains   Skip chain-name validation against the chain-selectors registry (for experimental chains)
+  -e, --env string             Path to .env file which contains sensitive info
+      --non-interactive        Fail instead of prompting; requires all inputs via flags
+  -R, --project-root string    Path to the project root
+  -E, --public-env string      Path to .env.public file which contains shared, non-sensitive build config
+  -T, --target string          Use target settings from YAML config
+  -v, --verbose                Run command in VERBOSE mode
 ```
 
 ### SEE ALSO

--- a/docs/cre_whoami.md
+++ b/docs/cre_whoami.md
@@ -19,12 +19,13 @@ cre whoami [optional flags]
 ### Options inherited from parent commands
 
 ```
-  -e, --env string            Path to .env file which contains sensitive info
-      --non-interactive       Fail instead of prompting; requires all inputs via flags
-  -R, --project-root string   Path to the project root
-  -E, --public-env string     Path to .env.public file which contains shared, non-sensitive build config
-  -T, --target string         Use target settings from YAML config
-  -v, --verbose               Run command in VERBOSE mode
+      --allow-unknown-chains   Skip chain-name validation against the chain-selectors registry (for experimental chains)
+  -e, --env string             Path to .env file which contains sensitive info
+      --non-interactive        Fail instead of prompting; requires all inputs via flags
+  -R, --project-root string    Path to the project root
+  -E, --public-env string      Path to .env.public file which contains shared, non-sensitive build config
+  -T, --target string          Use target settings from YAML config
+  -v, --verbose                Run command in VERBOSE mode
 ```
 
 ### SEE ALSO

--- a/docs/cre_workflow.md
+++ b/docs/cre_workflow.md
@@ -19,12 +19,13 @@ cre workflow [optional flags]
 ### Options inherited from parent commands
 
 ```
-  -e, --env string            Path to .env file which contains sensitive info
-      --non-interactive       Fail instead of prompting; requires all inputs via flags
-  -R, --project-root string   Path to the project root
-  -E, --public-env string     Path to .env.public file which contains shared, non-sensitive build config
-  -T, --target string         Use target settings from YAML config
-  -v, --verbose               Run command in VERBOSE mode
+      --allow-unknown-chains   Skip chain-name validation against the chain-selectors registry (for experimental chains)
+  -e, --env string             Path to .env file which contains sensitive info
+      --non-interactive        Fail instead of prompting; requires all inputs via flags
+  -R, --project-root string    Path to the project root
+  -E, --public-env string      Path to .env.public file which contains shared, non-sensitive build config
+  -T, --target string          Use target settings from YAML config
+  -v, --verbose                Run command in VERBOSE mode
 ```
 
 ### SEE ALSO

--- a/docs/cre_workflow_activate.md
+++ b/docs/cre_workflow_activate.md
@@ -27,12 +27,13 @@ cre workflow activate ./my-workflow
 ### Options inherited from parent commands
 
 ```
-  -e, --env string            Path to .env file which contains sensitive info
-      --non-interactive       Fail instead of prompting; requires all inputs via flags
-  -R, --project-root string   Path to the project root
-  -E, --public-env string     Path to .env.public file which contains shared, non-sensitive build config
-  -T, --target string         Use target settings from YAML config
-  -v, --verbose               Run command in VERBOSE mode
+      --allow-unknown-chains   Skip chain-name validation against the chain-selectors registry (for experimental chains)
+  -e, --env string             Path to .env file which contains sensitive info
+      --non-interactive        Fail instead of prompting; requires all inputs via flags
+  -R, --project-root string    Path to the project root
+  -E, --public-env string      Path to .env.public file which contains shared, non-sensitive build config
+  -T, --target string          Use target settings from YAML config
+  -v, --verbose                Run command in VERBOSE mode
 ```
 
 ### SEE ALSO

--- a/docs/cre_workflow_build.md
+++ b/docs/cre_workflow_build.md
@@ -27,12 +27,13 @@ cre workflow build ./my-workflow
 ### Options inherited from parent commands
 
 ```
-  -e, --env string            Path to .env file which contains sensitive info
-      --non-interactive       Fail instead of prompting; requires all inputs via flags
-  -R, --project-root string   Path to the project root
-  -E, --public-env string     Path to .env.public file which contains shared, non-sensitive build config
-  -T, --target string         Use target settings from YAML config
-  -v, --verbose               Run command in VERBOSE mode
+      --allow-unknown-chains   Skip chain-name validation against the chain-selectors registry (for experimental chains)
+  -e, --env string             Path to .env file which contains sensitive info
+      --non-interactive        Fail instead of prompting; requires all inputs via flags
+  -R, --project-root string    Path to the project root
+  -E, --public-env string      Path to .env.public file which contains shared, non-sensitive build config
+  -T, --target string          Use target settings from YAML config
+  -v, --verbose                Run command in VERBOSE mode
 ```
 
 ### SEE ALSO

--- a/docs/cre_workflow_custom-build.md
+++ b/docs/cre_workflow_custom-build.md
@@ -26,12 +26,13 @@ cre workflow custom-build ./my-workflow
 ### Options inherited from parent commands
 
 ```
-  -e, --env string            Path to .env file which contains sensitive info
-      --non-interactive       Fail instead of prompting; requires all inputs via flags
-  -R, --project-root string   Path to the project root
-  -E, --public-env string     Path to .env.public file which contains shared, non-sensitive build config
-  -T, --target string         Use target settings from YAML config
-  -v, --verbose               Run command in VERBOSE mode
+      --allow-unknown-chains   Skip chain-name validation against the chain-selectors registry (for experimental chains)
+  -e, --env string             Path to .env file which contains sensitive info
+      --non-interactive        Fail instead of prompting; requires all inputs via flags
+  -R, --project-root string    Path to the project root
+  -E, --public-env string      Path to .env.public file which contains shared, non-sensitive build config
+  -T, --target string          Use target settings from YAML config
+  -v, --verbose                Run command in VERBOSE mode
 ```
 
 ### SEE ALSO

--- a/docs/cre_workflow_delete.md
+++ b/docs/cre_workflow_delete.md
@@ -27,12 +27,13 @@ cre workflow delete ./my-workflow
 ### Options inherited from parent commands
 
 ```
-  -e, --env string            Path to .env file which contains sensitive info
-      --non-interactive       Fail instead of prompting; requires all inputs via flags
-  -R, --project-root string   Path to the project root
-  -E, --public-env string     Path to .env.public file which contains shared, non-sensitive build config
-  -T, --target string         Use target settings from YAML config
-  -v, --verbose               Run command in VERBOSE mode
+      --allow-unknown-chains   Skip chain-name validation against the chain-selectors registry (for experimental chains)
+  -e, --env string             Path to .env file which contains sensitive info
+      --non-interactive        Fail instead of prompting; requires all inputs via flags
+  -R, --project-root string    Path to the project root
+  -E, --public-env string      Path to .env.public file which contains shared, non-sensitive build config
+  -T, --target string          Use target settings from YAML config
+  -v, --verbose                Run command in VERBOSE mode
 ```
 
 ### SEE ALSO

--- a/docs/cre_workflow_deploy.md
+++ b/docs/cre_workflow_deploy.md
@@ -34,12 +34,13 @@ cre workflow deploy ./my-workflow
 ### Options inherited from parent commands
 
 ```
-  -e, --env string            Path to .env file which contains sensitive info
-      --non-interactive       Fail instead of prompting; requires all inputs via flags
-  -R, --project-root string   Path to the project root
-  -E, --public-env string     Path to .env.public file which contains shared, non-sensitive build config
-  -T, --target string         Use target settings from YAML config
-  -v, --verbose               Run command in VERBOSE mode
+      --allow-unknown-chains   Skip chain-name validation against the chain-selectors registry (for experimental chains)
+  -e, --env string             Path to .env file which contains sensitive info
+      --non-interactive        Fail instead of prompting; requires all inputs via flags
+  -R, --project-root string    Path to the project root
+  -E, --public-env string      Path to .env.public file which contains shared, non-sensitive build config
+  -T, --target string          Use target settings from YAML config
+  -v, --verbose                Run command in VERBOSE mode
 ```
 
 ### SEE ALSO

--- a/docs/cre_workflow_get.md
+++ b/docs/cre_workflow_get.md
@@ -27,12 +27,13 @@ cre workflow get ./my-workflow --target staging
 ### Options inherited from parent commands
 
 ```
-  -e, --env string            Path to .env file which contains sensitive info
-      --non-interactive       Fail instead of prompting; requires all inputs via flags
-  -R, --project-root string   Path to the project root
-  -E, --public-env string     Path to .env.public file which contains shared, non-sensitive build config
-  -T, --target string         Use target settings from YAML config
-  -v, --verbose               Run command in VERBOSE mode
+      --allow-unknown-chains   Skip chain-name validation against the chain-selectors registry (for experimental chains)
+  -e, --env string             Path to .env file which contains sensitive info
+      --non-interactive        Fail instead of prompting; requires all inputs via flags
+  -R, --project-root string    Path to the project root
+  -E, --public-env string      Path to .env.public file which contains shared, non-sensitive build config
+  -T, --target string          Use target settings from YAML config
+  -v, --verbose                Run command in VERBOSE mode
 ```
 
 ### SEE ALSO

--- a/docs/cre_workflow_hash.md
+++ b/docs/cre_workflow_hash.md
@@ -32,12 +32,13 @@ cre workflow hash <workflow-folder-path> [optional flags]
 ### Options inherited from parent commands
 
 ```
-  -e, --env string            Path to .env file which contains sensitive info
-      --non-interactive       Fail instead of prompting; requires all inputs via flags
-  -R, --project-root string   Path to the project root
-  -E, --public-env string     Path to .env.public file which contains shared, non-sensitive build config
-  -T, --target string         Use target settings from YAML config
-  -v, --verbose               Run command in VERBOSE mode
+      --allow-unknown-chains   Skip chain-name validation against the chain-selectors registry (for experimental chains)
+  -e, --env string             Path to .env file which contains sensitive info
+      --non-interactive        Fail instead of prompting; requires all inputs via flags
+  -R, --project-root string    Path to the project root
+  -E, --public-env string      Path to .env.public file which contains shared, non-sensitive build config
+  -T, --target string          Use target settings from YAML config
+  -v, --verbose                Run command in VERBOSE mode
 ```
 
 ### SEE ALSO

--- a/docs/cre_workflow_limits.md
+++ b/docs/cre_workflow_limits.md
@@ -15,12 +15,13 @@ The limits command provides tools for managing workflow simulation limits.
 ### Options inherited from parent commands
 
 ```
-  -e, --env string            Path to .env file which contains sensitive info
-      --non-interactive       Fail instead of prompting; requires all inputs via flags
-  -R, --project-root string   Path to the project root
-  -E, --public-env string     Path to .env.public file which contains shared, non-sensitive build config
-  -T, --target string         Use target settings from YAML config
-  -v, --verbose               Run command in VERBOSE mode
+      --allow-unknown-chains   Skip chain-name validation against the chain-selectors registry (for experimental chains)
+  -e, --env string             Path to .env file which contains sensitive info
+      --non-interactive        Fail instead of prompting; requires all inputs via flags
+  -R, --project-root string    Path to the project root
+  -E, --public-env string      Path to .env.public file which contains shared, non-sensitive build config
+  -T, --target string          Use target settings from YAML config
+  -v, --verbose                Run command in VERBOSE mode
 ```
 
 ### SEE ALSO

--- a/docs/cre_workflow_limits_export.md
+++ b/docs/cre_workflow_limits_export.md
@@ -26,12 +26,13 @@ cre workflow limits export > my-limits.json
 ### Options inherited from parent commands
 
 ```
-  -e, --env string            Path to .env file which contains sensitive info
-      --non-interactive       Fail instead of prompting; requires all inputs via flags
-  -R, --project-root string   Path to the project root
-  -E, --public-env string     Path to .env.public file which contains shared, non-sensitive build config
-  -T, --target string         Use target settings from YAML config
-  -v, --verbose               Run command in VERBOSE mode
+      --allow-unknown-chains   Skip chain-name validation against the chain-selectors registry (for experimental chains)
+  -e, --env string             Path to .env file which contains sensitive info
+      --non-interactive        Fail instead of prompting; requires all inputs via flags
+  -R, --project-root string    Path to the project root
+  -E, --public-env string      Path to .env.public file which contains shared, non-sensitive build config
+  -T, --target string          Use target settings from YAML config
+  -v, --verbose                Run command in VERBOSE mode
 ```
 
 ### SEE ALSO

--- a/docs/cre_workflow_list.md
+++ b/docs/cre_workflow_list.md
@@ -32,12 +32,13 @@ cre workflow list
 ### Options inherited from parent commands
 
 ```
-  -e, --env string            Path to .env file which contains sensitive info
-      --non-interactive       Fail instead of prompting; requires all inputs via flags
-  -R, --project-root string   Path to the project root
-  -E, --public-env string     Path to .env.public file which contains shared, non-sensitive build config
-  -T, --target string         Use target settings from YAML config
-  -v, --verbose               Run command in VERBOSE mode
+      --allow-unknown-chains   Skip chain-name validation against the chain-selectors registry (for experimental chains)
+  -e, --env string             Path to .env file which contains sensitive info
+      --non-interactive        Fail instead of prompting; requires all inputs via flags
+  -R, --project-root string    Path to the project root
+  -E, --public-env string      Path to .env.public file which contains shared, non-sensitive build config
+  -T, --target string          Use target settings from YAML config
+  -v, --verbose                Run command in VERBOSE mode
 ```
 
 ### SEE ALSO

--- a/docs/cre_workflow_pause.md
+++ b/docs/cre_workflow_pause.md
@@ -27,12 +27,13 @@ cre workflow pause ./my-workflow
 ### Options inherited from parent commands
 
 ```
-  -e, --env string            Path to .env file which contains sensitive info
-      --non-interactive       Fail instead of prompting; requires all inputs via flags
-  -R, --project-root string   Path to the project root
-  -E, --public-env string     Path to .env.public file which contains shared, non-sensitive build config
-  -T, --target string         Use target settings from YAML config
-  -v, --verbose               Run command in VERBOSE mode
+      --allow-unknown-chains   Skip chain-name validation against the chain-selectors registry (for experimental chains)
+  -e, --env string             Path to .env file which contains sensitive info
+      --non-interactive        Fail instead of prompting; requires all inputs via flags
+  -R, --project-root string    Path to the project root
+  -E, --public-env string      Path to .env.public file which contains shared, non-sensitive build config
+  -T, --target string          Use target settings from YAML config
+  -v, --verbose                Run command in VERBOSE mode
 ```
 
 ### SEE ALSO

--- a/docs/cre_workflow_simulate.md
+++ b/docs/cre_workflow_simulate.md
@@ -37,12 +37,13 @@ cre workflow simulate ./my-workflow
 ### Options inherited from parent commands
 
 ```
-  -e, --env string            Path to .env file which contains sensitive info
-      --non-interactive       Fail instead of prompting; requires all inputs via flags
-  -R, --project-root string   Path to the project root
-  -E, --public-env string     Path to .env.public file which contains shared, non-sensitive build config
-  -T, --target string         Use target settings from YAML config
-  -v, --verbose               Run command in VERBOSE mode
+      --allow-unknown-chains   Skip chain-name validation against the chain-selectors registry (for experimental chains)
+  -e, --env string             Path to .env file which contains sensitive info
+      --non-interactive        Fail instead of prompting; requires all inputs via flags
+  -R, --project-root string    Path to the project root
+  -E, --public-env string      Path to .env.public file which contains shared, non-sensitive build config
+  -T, --target string          Use target settings from YAML config
+  -v, --verbose                Run command in VERBOSE mode
 ```
 
 ### SEE ALSO

--- a/docs/cre_workflow_supported-chains.md
+++ b/docs/cre_workflow_supported-chains.md
@@ -23,12 +23,13 @@ cre workflow supported-chains
 ### Options inherited from parent commands
 
 ```
-  -e, --env string            Path to .env file which contains sensitive info
-      --non-interactive       Fail instead of prompting; requires all inputs via flags
-  -R, --project-root string   Path to the project root
-  -E, --public-env string     Path to .env.public file which contains shared, non-sensitive build config
-  -T, --target string         Use target settings from YAML config
-  -v, --verbose               Run command in VERBOSE mode
+      --allow-unknown-chains   Skip chain-name validation against the chain-selectors registry (for experimental chains)
+  -e, --env string             Path to .env file which contains sensitive info
+      --non-interactive        Fail instead of prompting; requires all inputs via flags
+  -R, --project-root string    Path to the project root
+  -E, --public-env string      Path to .env.public file which contains shared, non-sensitive build config
+  -T, --target string          Use target settings from YAML config
+  -v, --verbose                Run command in VERBOSE mode
 ```
 
 ### SEE ALSO

--- a/internal/settings/settings_get.go
+++ b/internal/settings/settings_get.go
@@ -262,16 +262,69 @@ func ChainNameFromSelectorString(raw string) (string, error) {
 	return GetChainNameByChainSelector(sel)
 }
 
+// GetChainSelectorByChainName resolves a chain name to its chain selector across
+// all chain families supported by chain-selectors (EVM, Aptos, Solana, Sui,
+// Tron, Ton, Starknet, Stellar, Canton). Returns an error if the name is not
+// found in any family.
 func GetChainSelectorByChainName(name string) (uint64, error) {
-	chainID, err := chainSelectors.ChainIdFromName(name)
-	if err != nil {
-		return 0, fmt.Errorf("failed to get chain ID from name %q: %w\n  Run 'cre workflow supported-chains' to see all valid chain names", name, err)
+	if chainID, err := chainSelectors.ChainIdFromName(name); err == nil {
+		selector, selErr := chainSelectors.SelectorFromChainId(chainID)
+		if selErr != nil {
+			return 0, fmt.Errorf("failed to get selector from chain ID %d: %w", chainID, selErr)
+		}
+		return selector, nil
 	}
 
-	selector, err := chainSelectors.SelectorFromChainId(chainID)
-	if err != nil {
-		return 0, fmt.Errorf("failed to get selector from chain ID %d: %w", chainID, err)
+	if selector, ok := findNonEVMSelectorByName(name); ok {
+		return selector, nil
 	}
 
-	return selector, nil
+	return 0, fmt.Errorf("chain not found for name %q\n  Run 'cre workflow supported-chains' to see all valid chain names", name)
+}
+
+// findNonEVMSelectorByName looks up a chain name in every non-EVM family
+// registered with chain-selectors. The EVM family is intentionally excluded
+// because ChainIdFromName already covers it.
+func findNonEVMSelectorByName(name string) (uint64, bool) {
+	for _, c := range chainSelectors.AptosALL {
+		if c.Name == name {
+			return c.Selector, true
+		}
+	}
+	for _, c := range chainSelectors.SolanaALL {
+		if c.Name == name {
+			return c.Selector, true
+		}
+	}
+	for _, c := range chainSelectors.SuiALL {
+		if c.Name == name {
+			return c.Selector, true
+		}
+	}
+	for _, c := range chainSelectors.TronALL {
+		if c.Name == name {
+			return c.Selector, true
+		}
+	}
+	for _, c := range chainSelectors.TonALL {
+		if c.Name == name {
+			return c.Selector, true
+		}
+	}
+	for _, c := range chainSelectors.StarknetALL {
+		if c.Name == name {
+			return c.Selector, true
+		}
+	}
+	for _, c := range chainSelectors.StellarALL {
+		if c.Name == name {
+			return c.Selector, true
+		}
+	}
+	for _, c := range chainSelectors.CantonALL {
+		if c.Name == name {
+			return c.Selector, true
+		}
+	}
+	return 0, false
 }

--- a/internal/settings/settings_load.go
+++ b/internal/settings/settings_load.go
@@ -47,6 +47,7 @@ type flagNames struct {
 	NonInteractive       Flag
 	SkipConfirmation     Flag
 	ChangesetFile        Flag
+	AllowUnknownChains   Flag
 }
 
 var Flags = flagNames{
@@ -64,6 +65,7 @@ var Flags = flagNames{
 	NonInteractive:       Flag{"non-interactive", ""},
 	SkipConfirmation:     Flag{"yes", "y"},
 	ChangesetFile:        Flag{"changeset-file", ""},
+	AllowUnknownChains:   Flag{"allow-unknown-chains", ""},
 }
 
 func AddTxnTypeFlags(cmd *cobra.Command) {

--- a/internal/settings/workflow_settings.go
+++ b/internal/settings/workflow_settings.go
@@ -163,7 +163,7 @@ func loadWorkflowSettings(logger *zerolog.Logger, v *viper.Viper, cmd *cobra.Com
 		return WorkflowSettings{}, errors.Wrap(err, "for target "+target)
 	}
 
-	if err := validateSettings(&workflowSettings); err != nil {
+	if err := validateSettings(&workflowSettings, v.GetBool(Flags.AllowUnknownChains.Name)); err != nil {
 		return WorkflowSettings{}, errors.Wrap(err, "for target "+target)
 	}
 
@@ -260,11 +260,14 @@ func flattenWorkflowSettingsToViper(v *viper.Viper, target string, effectiveWork
 	return nil
 }
 
-func validateSettings(config *WorkflowSettings) error {
+func validateSettings(config *WorkflowSettings, allowUnknownChains bool) error {
 	// TODO validate that all chain names mentioned for the contracts above have a matching URL specified
 	for _, rpc := range config.RPCs {
 		if err := isValidRpcUrl(rpc.Url); err != nil {
 			return errors.Wrap(err, "invalid rpc url for "+rpc.ChainName)
+		}
+		if allowUnknownChains {
+			continue
 		}
 		if err := IsValidChainName(rpc.ChainName); err != nil {
 			return err


### PR DESCRIPTION
# Summary
- Updated workflow supported-chains support to also list non-evms
- Added a flag `--allow-unknown-chains to skip` to skip chain-name validation