### PR TITLE
fix: preserve paused status on private registry workflow update

### DIFF
--- a/cmd/workflow/deploy/private_registry_test.go
+++ b/cmd/workflow/deploy/private_registry_test.go
@@ -52,6 +52,52 @@ func TestBuildPrivateRegistryInput(t *testing.T) {
 		assert.Equal(t, "v1-tag", *input.Tag)
 	})
 
+	t.Run("preserves paused status if existing workflow is paused", func(t *testing.T) {
+		t.Parallel()
+		simulatedEnvironment := chainsim.NewSimulatedEnvironment(t)
+		defer simulatedEnvironment.Close()
+
+		ctx, buf := simulatedEnvironment.NewRuntimeContextWithBufferedOutput()
+		h := newHandler(ctx, buf)
+		h.inputs = Inputs{
+			WorkflowName: "my-workflow",
+			BinaryURL:    "https://storage.example.com/binary.wasm",
+			DonFamily:    "zone-a",
+		}
+		h.workflowArtifact = &workflowArtifact{
+			WorkflowID: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+		}
+		status := workflowStatusPaused
+		h.existingWorkflowStatus = &status
+
+		input := h.buildPrivateRegistryInput()
+
+		assert.Equal(t, privateregistryclient.WorkflowStatusPaused, input.Status)
+	})
+
+	t.Run("sets active status if existing workflow is active", func(t *testing.T) {
+		t.Parallel()
+		simulatedEnvironment := chainsim.NewSimulatedEnvironment(t)
+		defer simulatedEnvironment.Close()
+
+		ctx, buf := simulatedEnvironment.NewRuntimeContextWithBufferedOutput()
+		h := newHandler(ctx, buf)
+		h.inputs = Inputs{
+			WorkflowName: "my-workflow",
+			BinaryURL:    "https://storage.example.com/binary.wasm",
+			DonFamily:    "zone-a",
+		}
+		h.workflowArtifact = &workflowArtifact{
+			WorkflowID: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+		}
+		status := workflowStatusActive
+		h.existingWorkflowStatus = &status
+
+		input := h.buildPrivateRegistryInput()
+
+		assert.Equal(t, privateregistryclient.WorkflowStatusActive, input.Status)
+	})
+
 	t.Run("includes config URL when present", func(t *testing.T) {
 		t.Parallel()
 		simulatedEnvironment := chainsim.NewSimulatedEnvironment(t)

--- a/cmd/workflow/deploy/registry_deploy_strategy_private.go
+++ b/cmd/workflow/deploy/registry_deploy_strategy_private.go
@@ -78,9 +78,14 @@ func (a *privateRegistryDeployStrategy) Upsert() error {
 }
 
 func (h *handler) buildPrivateRegistryInput() privateregistryclient.OffchainWorkflowInput {
+	status := privateregistryclient.WorkflowStatusActive
+	if h.existingWorkflowStatus != nil && *h.existingWorkflowStatus == workflowStatusPaused {
+		status = privateregistryclient.WorkflowStatusPaused
+	}
+
 	input := privateregistryclient.OffchainWorkflowInput{
 		WorkflowID:   h.workflowArtifact.WorkflowID,
-		Status:       privateregistryclient.WorkflowStatusActive,
+		Status:       status,
 		WorkflowName: h.inputs.WorkflowName,
 		BinaryURL:    h.inputs.BinaryURL,
 		DonFamily:    h.inputs.DonFamily,


### PR DESCRIPTION
## Summary
* Updates `buildPrivateRegistryInput` to preserve the paused status of an existing workflow when updating it via the private registry
* Prevents the issue where intentionally paused workflows were silently re-activated upon deployment of an updated binary
* Adds corresponding test coverage

## Test plan
* Unit tests added to `private_registry_test.go` to verify that `buildPrivateRegistryInput` correctly sets the status to `WorkflowStatusPaused` when updating an already paused workflow, and `WorkflowStatusActive` otherwise.

Made with [Cursor](https://cursor.com)