### PR TITLE
Fix: Check workflowID in private registry deploy strategy (DEVSVCS-4930)

### DIFF
--- a/cmd/workflow/deploy/private_registry_test.go
+++ b/cmd/workflow/deploy/private_registry_test.go
@@ -125,9 +125,11 @@ func TestCheckWorkflowExists_PrivateRegistry(t *testing.T) {
 		name         string
 		serverStatus int
 		response     map[string]any
+		workflowID   string
 		wantExists   bool
 		wantStatus   *uint8
 		wantErr      bool
+		errMsg       string
 	}{
 		{
 			name:         "found active workflow returns active status",
@@ -151,6 +153,7 @@ func TestCheckWorkflowExists_PrivateRegistry(t *testing.T) {
 					},
 				},
 			},
+			workflowID: "different-workflow-id",
 			wantExists: true,
 			wantStatus: uint8Ptr(0),
 			wantErr:    false,
@@ -177,9 +180,38 @@ func TestCheckWorkflowExists_PrivateRegistry(t *testing.T) {
 					},
 				},
 			},
+			workflowID: "different-workflow-id",
 			wantExists: true,
 			wantStatus: uint8Ptr(1),
 			wantErr:    false,
+		},
+		{
+			name:         "found workflow with same ID returns error",
+			serverStatus: http.StatusOK,
+			response: map[string]any{
+				"data": map[string]any{
+					"getOffchainWorkflowByName": map[string]any{
+						"workflow": map[string]any{
+							"workflowId":     "00a2b96d2f06961c3e0cf6fbba5cfa30d3b577026de094e5202d5fc3e3aabb87",
+							"owner":          "6028e8bd8759240ffe7bd80bdd5c99ca662f3363",
+							"createdAt":      "2026-04-10T14:07:25Z",
+							"status":         "WORKFLOW_STATUS_ACTIVE",
+							"workflowName":   "jnowak-workflow-test-v5",
+							"binaryUrl":      "https://storage.cre.stage.external.griddle.sh/artifacts/00a2b96d2f06961c3e0cf6fbba5cfa30d3b577026de094e5202d5fc3e3aabb87/binary.wasm",
+							"configUrl":      "https://storage.cre.stage.external.griddle.sh/artifacts/00a2b96d2f06961c3e0cf6fbba5cfa30d3b577026de094e5202d5fc3e3aabb87/config",
+							"tag":            "",
+							"attributes":     "{\"app\": \"test\"}",
+							"donFamily":      "zone-a",
+							"organizationId": "org_meoybOR7KEkNhEFf",
+						},
+					},
+				},
+			},
+			workflowID: "00a2b96d2f06961c3e0cf6fbba5cfa30d3b577026de094e5202d5fc3e3aabb87",
+			wantExists: false,
+			wantStatus: nil,
+			wantErr:    true,
+			errMsg:     "workflow with id 00a2b96d2f06961c3e0cf6fbba5cfa30d3b577026de094e5202d5fc3e3aabb87 already exists",
 		},
 		{
 			name:         "not found returns no error and no status",
@@ -196,6 +228,7 @@ func TestCheckWorkflowExists_PrivateRegistry(t *testing.T) {
 				},
 				"data": nil,
 			},
+			workflowID: "different-workflow-id",
 			wantExists: false,
 			wantStatus: nil,
 			wantErr:    false,
@@ -210,6 +243,7 @@ func TestCheckWorkflowExists_PrivateRegistry(t *testing.T) {
 					},
 				},
 			},
+			workflowID: "different-workflow-id",
 			wantExists: false,
 			wantStatus: nil,
 			wantErr:    true,
@@ -234,9 +268,12 @@ func TestCheckWorkflowExists_PrivateRegistry(t *testing.T) {
 			h.environmentSet.GraphQLURL = gqlServer.URL
 			strategy := newPrivateRegistryDeployStrategy(h)
 
-			exists, status, err := strategy.CheckWorkflowExists("", "jnowak-workflow-test-v5", "", "")
+			exists, status, err := strategy.CheckWorkflowExists("", "jnowak-workflow-test-v5", "", tt.workflowID)
 			if tt.wantErr {
 				require.Error(t, err)
+				if tt.errMsg != "" {
+					assert.Equal(t, tt.errMsg, err.Error())
+				}
 			} else {
 				require.NoError(t, err)
 			}

--- a/cmd/workflow/deploy/registry_deploy_strategy_private.go
+++ b/cmd/workflow/deploy/registry_deploy_strategy_private.go
@@ -31,11 +31,14 @@ func (a *privateRegistryDeployStrategy) RunPreDeployChecks() error {
 	return nil
 }
 
-func (a *privateRegistryDeployStrategy) CheckWorkflowExists(_, workflowName, _, _ string) (bool, *uint8, error) {
+func (a *privateRegistryDeployStrategy) CheckWorkflowExists(_, workflowName, _, workflowID string) (bool, *uint8, error) {
 	a.ensureClient()
 
 	workflow, err := a.prc.GetWorkflowByName(workflowName)
 	if err == nil {
+		if workflow.WorkflowID == workflowID {
+			return false, nil, fmt.Errorf("workflow with id %s already exists", workflowID)
+		}
 		return true, offchainStatusToUint8(workflow.Status), nil
 	}
 	if isWorkflowNotFoundError(err) {


### PR DESCRIPTION
## Summary
- Updated `CheckWorkflowExists` method to include `workflowID` parameter.
- Added logic to return an error if a workflow with the same ID already exists in the private registry.
- Expanded unit tests to cover new scenarios, including error handling for duplicate workflow IDs.

Fixes [DEVSVCS-4930](https://smartcontract-it.atlassian.net/browse/DEVSVCS-4930)

Made with [Cursor](https://cursor.com)