### PR TITLE
Implement SecureRemove function for safer file deletion and update logout handler to use it.

### DIFF
--- a/cmd/logout/logout.go
+++ b/cmd/logout/logout.go
@@ -88,7 +88,7 @@ func (h *handler) execute() error {
 		}
 	}
 
-	if err := os.Remove(credPath); err != nil && !os.IsNotExist(err) {
+	if err := credentials.SecureRemove(credPath); err != nil {
 		spinner.Stop()
 		return fmt.Errorf("failed to delete credentials file: %w", err)
 	}

--- a/internal/credentials/credentials.go
+++ b/internal/credentials/credentials.go
@@ -106,6 +106,41 @@ func SaveCredentials(tokenSet *CreLoginTokenSet) error {
 	return nil
 }
 
+// SecureRemove overwrites a file with zeroes before deleting it.
+func SecureRemove(path string) error {
+	f, err := os.OpenFile(path, os.O_RDWR, 0)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+
+	info, err := f.Stat()
+	if err != nil {
+		_ = f.Close()
+		return err
+	}
+
+	size := info.Size()
+	if size > 0 {
+		zeros := make([]byte, size)
+		if _, err := f.WriteAt(zeros, 0); err != nil {
+			_ = f.Close()
+			return err
+		}
+		if err := f.Sync(); err != nil {
+			_ = f.Close()
+			return err
+		}
+	}
+
+	if err := f.Close(); err != nil {
+		return err
+	}
+	return os.Remove(path)
+}
+
 // decodeJWTClaims extracts the claims map from the access token JWT payload.
 func (c *Credentials) decodeJWTClaims() (map[string]interface{}, error) {
 	if c.Tokens == nil || c.Tokens.AccessToken == "" {

--- a/internal/credentials/credentials_test.go
+++ b/internal/credentials/credentials_test.go
@@ -411,3 +411,28 @@ func TestCheckIsUngatedOrganization_InvalidJWTFormat(t *testing.T) {
 		})
 	}
 }
+
+func TestSecureRemove(t *testing.T) {
+	t.Run("missing file is no-op", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "missing.yaml")
+		if err := SecureRemove(path); err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+	})
+
+	t.Run("overwrites with zeroes before delete", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), ConfigFile)
+		secret := []byte("AccessToken: super-secret-token\n")
+		if err := os.WriteFile(path, secret, 0o600); err != nil {
+			t.Fatalf("write file: %v", err)
+		}
+
+		if err := SecureRemove(path); err != nil {
+			t.Fatalf("SecureRemove: %v", err)
+		}
+
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Fatal("expected file to be removed")
+		}
+	})
+}


### PR DESCRIPTION
[DEVSVCS-4953](https://smartcontract-it.atlassian.net/browse/DEVSVCS-4953)

Enhance the security of credential file deletion by ensuring sensitive data is securely erased before removal. The main change is the introduction of a new `SecureRemove` function, which overwrites credential files with zeroes before deleting them. The logout process and associated tests have also been updated to use this secure deletion method.

**Security improvements:**

* Added a new `SecureRemove` function in `internal/credentials/credentials.go` that overwrites files with zeroes before deleting them, preventing potential recovery of sensitive data.
* Updated the logout handler in `cmd/logout/logout.go` to use `credentials.SecureRemove` instead of `os.Remove` for deleting the credentials file.