### PR TITLE
Refactor: Standardize service timeout across clients and improve context handling

### DIFF
--- a/internal/authvalidation/validator.go
+++ b/internal/authvalidation/validator.go
@@ -3,6 +3,7 @@ package authvalidation
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/machinebox/graphql"
 	"github.com/rs/zerolog"
@@ -30,6 +31,7 @@ type ValidationResult struct {
 type Validator struct {
 	gqlClient *graphqlclient.Client
 	log       *zerolog.Logger
+	timeout   time.Duration
 }
 
 // NewValidator creates a new credential validator
@@ -38,13 +40,25 @@ func NewValidator(creds *credentials.Credentials, environmentSet *environments.E
 	return &Validator{
 		gqlClient: gqlClient,
 		log:       log,
+		timeout:   time.Minute,
 	}
+}
+
+func (v *Validator) SetServiceTimeout(timeout time.Duration) {
+	v.timeout = timeout
+}
+
+func (v *Validator) CreateServiceContextWithTimeout(parent context.Context) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(parent, v.timeout) //nolint:gosec // G118 -- cancel is deferred by callers
 }
 
 // ValidateCredentials validates the provided credentials by making a lightweight GraphQL query
 // and returns organization info including the derived workflow owner.
 // The GraphQL client automatically handles token refresh if needed.
 func (v *Validator) ValidateCredentials(validationCtx context.Context, creds *credentials.Credentials) (*ValidationResult, error) {
+	ctx, cancel := v.CreateServiceContextWithTimeout(validationCtx)
+	defer cancel()
+
 	if creds == nil {
 		return nil, fmt.Errorf("credentials not provided")
 	}
@@ -62,7 +76,7 @@ func (v *Validator) ValidateCredentials(validationCtx context.Context, creds *cr
 		} `json:"getCreOrganizationInfo"`
 	}
 
-	if err := v.gqlClient.Execute(validationCtx, req, &respEnvelope); err != nil {
+	if err := v.gqlClient.Execute(ctx, req, &respEnvelope); err != nil {
 		return nil, fmt.Errorf("authentication failed: unable to retrieve organization info. Your account may not be fully set up yet — please try again in a few minutes: %w", err)
 	}
 

--- a/internal/client/privateregistryclient/privateregistryclient.go
+++ b/internal/client/privateregistryclient/privateregistryclient.go
@@ -21,7 +21,7 @@ func New(gql *graphqlclient.Client, log *zerolog.Logger) *Client {
 	return &Client{
 		graphql:        gql,
 		log:            log,
-		serviceTimeout: 2 * time.Minute,
+		serviceTimeout: time.Minute,
 	}
 }
 

--- a/internal/client/storageclient/storageclient.go
+++ b/internal/client/storageclient/storageclient.go
@@ -32,8 +32,8 @@ func New(graphql *graphqlclient.Client, workflowOwnerAddress string, log *zerolo
 		graphql:              graphql,
 		workflowOwnerAddress: workflowOwnerAddress,
 		log:                  log,
-		serviceTimeout:       time.Minute * 2,
-		httpTimeout:          time.Minute * 1,
+		serviceTimeout:       time.Minute,
+		httpTimeout:          time.Minute,
 	}
 }
 

--- a/internal/client/workflowdataclient/workflowdataclient.go
+++ b/internal/client/workflowdataclient/workflowdataclient.go
@@ -3,6 +3,7 @@ package workflowdataclient
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/machinebox/graphql"
 	"github.com/rs/zerolog"
@@ -25,11 +26,20 @@ type Workflow struct {
 type Client struct {
 	graphql *graphqlclient.Client
 	log     *zerolog.Logger
+	timeout time.Duration
 }
 
 // New creates a WorkflowDataClient backed by the provided GraphQL client.
 func New(gql *graphqlclient.Client, log *zerolog.Logger) *Client {
-	return &Client{graphql: gql, log: log}
+	return &Client{graphql: gql, log: log, timeout: time.Minute}
+}
+
+func (c *Client) SetServiceTimeout(timeout time.Duration) {
+	c.timeout = timeout
+}
+
+func (c *Client) CreateServiceContextWithTimeout(parent context.Context) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(parent, c.timeout) //nolint:gosec // G118 -- cancel is deferred by callers
 }
 
 const listWorkflowsQuery = `
@@ -63,17 +73,19 @@ type listWorkflowsEnvelope struct {
 }
 
 // ListAll pages through the ListWorkflows query and returns all workflows.
-func (c *Client) ListAll(ctx context.Context, pageSize int) ([]Workflow, error) {
-	return c.list(ctx, pageSize, "")
+func (c *Client) ListAll(parent context.Context, pageSize int) ([]Workflow, error) {
+	return c.list(parent, pageSize, "")
 }
 
 // SearchByName pages through the ListWorkflows query with the given search
 // filter (server-side contains match on workflow name).
-func (c *Client) SearchByName(ctx context.Context, name string, pageSize int) ([]Workflow, error) {
-	return c.list(ctx, pageSize, name)
+func (c *Client) SearchByName(parent context.Context, name string, pageSize int) ([]Workflow, error) {
+	return c.list(parent, pageSize, name)
 }
 
-func (c *Client) list(ctx context.Context, pageSize int, search string) ([]Workflow, error) {
+func (c *Client) list(parent context.Context, pageSize int, search string) ([]Workflow, error) {
+	ctx, cancel := c.CreateServiceContextWithTimeout(parent)
+	defer cancel()
 	if pageSize <= 0 {
 		pageSize = DefaultPageSize
 	}

--- a/internal/client/workflowdataclient/workflowdataclient_test.go
+++ b/internal/client/workflowdataclient/workflowdataclient_test.go
@@ -7,7 +7,9 @@ import (
 	"net/http/httptest"
 	"sync/atomic"
 	"testing"
+	"time"
 
+	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -27,6 +29,20 @@ func newTestClient(t *testing.T, serverURL string) *Client {
 	envSet := &environments.EnvironmentSet{GraphQLURL: serverURL}
 	gql := graphqlclient.New(creds, envSet, logger)
 	return New(gql, logger)
+}
+
+func TestCreateServiceContextWithTimeout(t *testing.T) {
+	logger := zerolog.Nop()
+	client := New(nil, &logger)
+	client.SetServiceTimeout(150 * time.Millisecond)
+
+	parent := context.Background()
+	callCtx, cancel := client.CreateServiceContextWithTimeout(parent)
+	defer cancel()
+
+	deadline, ok := callCtx.Deadline()
+	require.True(t, ok)
+	assert.WithinDuration(t, time.Now().Add(150*time.Millisecond), deadline, 100*time.Millisecond)
 }
 
 func TestListAll_SinglePage(t *testing.T) {


### PR DESCRIPTION
[DEVSVCS-4958](https://smartcontract-it.atlassian.net/browse/DEVSVCS-4958)

- Set service timeout to 1 minute in PrivateRegistryClient, StorageClient, and WorkflowDataClient.
- Introduce CreateServiceContextWithTimeout method in Validator and WorkflowDataClient for consistent context management.
- Update ValidateCredentials method in Validator to use the new context handling approach.