### PR TITLE
PLEX-3005 Point Aptos simulate at deployed mock forwarders

### DIFF
--- a/cmd/workflow/simulate/chain/aptos/supported_chains.go
+++ b/cmd/workflow/simulate/chain/aptos/supported_chains.go
@@ -6,13 +6,16 @@ import (
 	"github.com/smartcontractkit/cre-cli/cmd/workflow/simulate/chain"
 )
 
-// placeholderForwarder is used until canonical platform_mock addresses are
-// published per network. Users override via experimental-chains config
-// (chain-type: aptos).
-const placeholderForwarder = "0x0000000000000000000000000000000000000000000000000000000000000000"
+// platform_mock MockForwarder object addresses, deployed per network
+// (chainlink-aptos contracts/platform_mock, published via scripts/publish_mock.sh).
+// Users can still override via experimental-chains config (chain-type: aptos).
+const (
+	mainnetForwarder = "0xbe43e1d5f2432c31b0026661a4eab8969531c61d449b45a83d199a560314c6c4"
+	testnetForwarder = "0xef1c83c5c5c05f6604d17576a49570c28b49e4955d96d32e130c4ce5a1bc51b8"
+)
 
 // SupportedChains lists Aptos networks cre-cli simulate can target.
 var SupportedChains = []chain.ChainConfig{
-	{Selector: chainselectors.APTOS_MAINNET.Selector, Forwarder: placeholderForwarder},
-	{Selector: chainselectors.APTOS_TESTNET.Selector, Forwarder: placeholderForwarder},
+	{Selector: chainselectors.APTOS_MAINNET.Selector, Forwarder: mainnetForwarder},
+	{Selector: chainselectors.APTOS_TESTNET.Selector, Forwarder: testnetForwarder},
 }


### PR DESCRIPTION
## Summary
- Replace the all-zero Aptos forwarder placeholder with the deployed `platform_mock` MockForwarder object addresses for mainnet and testnet.

## Context
The MockForwarders are now deployed and frozen immutable on Aptos mainnet + testnet, so simulate can target them directly instead of requiring an `experimental-chains` override.

## Changes
- `cmd/workflow/simulate/chain/aptos/supported_chains.go`: mainnet `0xbe43e1d5…0314c6c4`, testnet `0xef1c83c5…1bc51b8`.

## Testing
- `go test ./cmd/workflow/simulate/chain/aptos/...` — pass.
- On-chain: `report()` verified on both networks (`ReportProcessed`).
  - mainnet: https://explorer.aptoslabs.com/txn/0x5a9688ef095541260236e610ba1c152e440b0107ea86236451dcc0f2869d022b?network=mainnet
  - testnet: https://explorer.aptoslabs.com/txn/0xcfdf271e26fa12331832fd4941934da209711e953877d5128f3aedbc96b375c3?network=testnet

## Notes
- `experimental-chains` override still applies.
- Forwarder packages are frozen immutable; no single-EOA upgrade control.