### PR TITLE
PLEX-3005 Run PR CI for capabilities-development branch

### DIFF
--- a/.github/workflows/pull-request-main.yml
+++ b/.github/workflows/pull-request-main.yml
@@ -6,6 +6,7 @@ on:
     branches:
       - main
       - "releases/**"
+      - capabilities-development
 
 env:
   # Ensure that a cached go version is used:


### PR DESCRIPTION
## Summary
- Add `capabilities-development` to the `pull_request` branch filter in `pull-request-main.yml` so the required CI runs for PRs targeting it.

## Context
PRs into `capabilities-development` never triggered the required checks (`ci-lint`, `ci-lint-misc`, `ci-test-unit`, `ci-test-e2e` ubuntu/windows) — the workflow only fired for `main` / `releases/**`. Those checks are required by the branch ruleset, so they sat permanently pending: PRs couldn't satisfy protection or enter the merge queue (deadlock). Surfaced while merging the Aptos mock-forwarder address change (#465), which targets `capabilities-development`.

## Changes
- `.github/workflows/pull-request-main.yml`: add `capabilities-development` to `on.pull_request.branches`.

## Notes
- For `pull_request` events GitHub reads the workflow from the **base branch**, so this fix only takes effect for PRs into `capabilities-development` once it also exists **on** `capabilities-development` (via the normal `main` → `capabilities-development` merge after this lands).
- Unblocks #465.