### PR TITLE
Run PR CI on capabilities-development branch

### DIFF
--- a/.github/workflows/pull-request-main.yml
+++ b/.github/workflows/pull-request-main.yml
@@ -6,6 +6,7 @@ on:
     branches:
       - main
       - "releases/**"
+      - capabilities-development
 
 env:
   # Ensure that a cached go version is used:


### PR DESCRIPTION
## Summary
- Add `capabilities-development` to the `pull_request` branch filter in `pull-request-main.yml`.

## Context
PRs targeting `capabilities-development` never triggered the required `ci-lint` / `ci-test-*` checks — the workflow only listened for `main` and `releases/**`, so those PRs could never satisfy branch protection. This branches from `capabilities-development`. Its own head supplies the trigger, so the checks self-trigger on this PR; once merged, every subsequent PR into `capabilities-development` inherits the trigger from the base.

## Changes
- `.github/workflows/pull-request-main.yml`: one line added to `on.pull_request.branches`.

## Testing
- CI on this PR itself is the test — `ci-lint` / `ci-test-*` should now run and pass.
