### PR TITLE
Fix DON family resolution to use tenant default over embedded config

### DIFF
--- a/cmd/workflow/activate/registry_activate_strategy_onchain.go
+++ b/cmd/workflow/activate/registry_activate_strategy_onchain.go
@@ -102,6 +102,7 @@ func (a *onchainRegistryActivateStrategy) Activate() error {
 		ui.Line()
 		ui.Bold("Details:")
 		ui.Dim(fmt.Sprintf("   Registry:         %s", h.runtimeContext.ResolvedRegistry.ID()))
+		ui.Dim(fmt.Sprintf("   DON Family:       %s", h.inputs.DonFamily))
 		ui.Dim(fmt.Sprintf("   Contract address: %s", oc.Address()))
 		ui.Dim(fmt.Sprintf("   Transaction hash: %s", txOut.Hash))
 		ui.Dim(fmt.Sprintf("   Workflow Name:    %s", workflowName))

--- a/cmd/workflow/activate/registry_activate_strategy_private.go
+++ b/cmd/workflow/activate/registry_activate_strategy_private.go
@@ -54,6 +54,7 @@ func (a *privateRegistryActivateStrategy) Activate() error {
 	ui.Line()
 	ui.Bold("Details:")
 	ui.Dim(fmt.Sprintf("   Registry:         %s", h.runtimeContext.ResolvedRegistry.ID()))
+	ui.Dim(fmt.Sprintf("   DON Family:       %s", h.runtimeContext.ResolvedRegistry.DonFamily()))
 	ui.Dim(fmt.Sprintf("   Workflow Name:    %s", result.WorkflowName))
 	ui.Dim(fmt.Sprintf("   Workflow ID:      %s", result.WorkflowID))
 	ui.Dim(fmt.Sprintf("   Status:           %s", privateregistryclient.FormatStatus(result.Status)))

--- a/cmd/workflow/common/display_workflow_details.go
+++ b/cmd/workflow/common/display_workflow_details.go
@@ -23,6 +23,7 @@ func DisplayWorkflowDetails(
 	ui.Line()
 	ui.Title(fmt.Sprintf("%s Workflow: %s", action, workflowName))
 	ui.Dim(fmt.Sprintf("Registry:      %s", runtimeContext.ResolvedRegistry.ID()))
+	ui.Dim(fmt.Sprintf("DON Family:    %s", runtimeContext.ResolvedRegistry.DonFamily()))
 	ui.Dim(fmt.Sprintf("Target:        %s", cfg.User.TargetName))
 	ui.Dim(fmt.Sprintf("Owner Address: %s", displayOwnerAddress))
 	ui.Line()

--- a/cmd/workflow/deploy/register.go
+++ b/cmd/workflow/deploy/register.go
@@ -71,6 +71,7 @@ func (h *handler) handleUpsert(ctx context.Context, params client.RegisterWorkfl
 		ui.Line()
 		ui.Bold("Details:")
 		ui.Dim(fmt.Sprintf("   Registry:         %s", h.runtimeContext.ResolvedRegistry.ID()))
+		ui.Dim(fmt.Sprintf("   DON Family:       %s", h.inputs.DonFamily))
 		ui.Dim(fmt.Sprintf("   Contract address: %s", onChain.Address()))
 		ui.Dim(fmt.Sprintf("   Transaction hash: %s", txOut.Hash))
 		ui.Dim(fmt.Sprintf("   Workflow Name:    %s", workflowName))

--- a/cmd/workflow/deploy/registry_deploy_strategy_private.go
+++ b/cmd/workflow/deploy/registry_deploy_strategy_private.go
@@ -67,6 +67,7 @@ func (a *privateRegistryDeployStrategy) Upsert(ctx context.Context) error {
 	ui.Line()
 	ui.Bold("Details:")
 	ui.Dim(fmt.Sprintf("   Registry:         %s", h.runtimeContext.ResolvedRegistry.ID()))
+	ui.Dim(fmt.Sprintf("   DON Family:       %s", h.inputs.DonFamily))
 	ui.Dim(fmt.Sprintf("   Workflow Name:    %s", result.WorkflowName))
 	ui.Dim(fmt.Sprintf("   Workflow ID:      %s", result.WorkflowID))
 	ui.Dim(fmt.Sprintf("   Status:           %s", privateregistryclient.FormatStatus(result.Status)))

--- a/cmd/workflow/pause/registry_pause_strategy_onchain.go
+++ b/cmd/workflow/pause/registry_pause_strategy_onchain.go
@@ -97,6 +97,7 @@ func (a *onchainRegistryPauseStrategy) Pause() error {
 		ui.Line()
 		ui.Bold("Details:")
 		ui.Dim(fmt.Sprintf("   Registry:         %s", h.runtimeContext.ResolvedRegistry.ID()))
+		ui.Dim(fmt.Sprintf("   DON Family:       %s", h.runtimeContext.ResolvedRegistry.DonFamily()))
 		ui.Dim(fmt.Sprintf("   Contract address: %s", oc.Address()))
 		ui.Dim(fmt.Sprintf("   Transaction hash: %s", txOut.Hash))
 		ui.Dim(fmt.Sprintf("   Workflow Name:    %s", workflowName))

--- a/cmd/workflow/pause/registry_pause_strategy_private.go
+++ b/cmd/workflow/pause/registry_pause_strategy_private.go
@@ -54,6 +54,7 @@ func (a *privateRegistryPauseStrategy) Pause() error {
 	ui.Line()
 	ui.Bold("Details:")
 	ui.Dim(fmt.Sprintf("   Registry:         %s", h.runtimeContext.ResolvedRegistry.ID()))
+	ui.Dim(fmt.Sprintf("   DON Family:       %s", result.DonFamily))
 	ui.Dim(fmt.Sprintf("   Workflow Name:    %s", result.WorkflowName))
 	ui.Dim(fmt.Sprintf("   Workflow ID:      %s", result.WorkflowID))
 	ui.Dim(fmt.Sprintf("   Status:           %s", privateregistryclient.FormatStatus(result.Status)))

--- a/internal/environments/environments.go
+++ b/internal/environments/environments.go
@@ -46,7 +46,7 @@ type EnvironmentSet struct {
 	WorkflowRegistryAddress          string `yaml:"CRE_CLI_WORKFLOW_REGISTRY_ADDRESS"`
 	WorkflowRegistryChainName        string `yaml:"CRE_CLI_WORKFLOW_REGISTRY_CHAIN_NAME"`
 	WorkflowRegistryChainExplorerURL string `yaml:"CRE_CLI_WORKFLOW_REGISTRY_CHAIN_EXPLORER_URL"`
-	DonFamily                        string `yaml:"CRE_CLI_DON_FAMILY"`
+	DonFamily                        string `yaml:"-"`
 }
 
 // RequiresVPN returns true if the GraphQL endpoint is on a private network

--- a/internal/environments/environments.yaml
+++ b/internal/environments/environments.yaml
@@ -5,7 +5,6 @@ ENVIRONMENTS:
     CRE_CLI_AUDIENCE: https://graphql.cre.dev.internal.griddle.sh/
     CRE_CLI_GRAPHQL_URL: https://graphql-cre-dev.tailf8f749.ts.net/graphql
     CRE_VAULT_DON_GATEWAY_URL: https://cre-gateway-one-zone-a.main.stage.cldev.sh/
-    CRE_CLI_DON_FAMILY: "zone-a"
 
     CRE_CLI_WORKFLOW_REGISTRY_ADDRESS: "0x7e69E853D9Ce50C2562a69823c80E01360019Cef"
     CRE_CLI_WORKFLOW_REGISTRY_CHAIN_NAME: "ethereum-testnet-sepolia" # eth-sepolia
@@ -17,7 +16,6 @@ ENVIRONMENTS:
     CRE_CLI_AUDIENCE: https://graphql.cre.stage.internal.griddle.sh/
     CRE_CLI_GRAPHQL_URL: https://graphql-cre-stage.tailf8f749.ts.net/graphql
     CRE_VAULT_DON_GATEWAY_URL: https://cre-gateway-one-zone-a.main.stage.cldev.sh/
-    CRE_CLI_DON_FAMILY: "zone-a"
 
     CRE_CLI_WORKFLOW_REGISTRY_ADDRESS: "0xaE55eB3EDAc48a1163EE2cbb1205bE1e90Ea1135"
     CRE_CLI_WORKFLOW_REGISTRY_CHAIN_NAME: "ethereum-testnet-sepolia" # eth-sepolia
@@ -29,7 +27,6 @@ ENVIRONMENTS:
     CRE_CLI_AUDIENCE: https://api.cre.chain.link/
     CRE_CLI_GRAPHQL_URL: https://api.cre.chain.link/graphql
     CRE_VAULT_DON_GATEWAY_URL: https://01.gateway.zone-a.cre.chain.link
-    CRE_CLI_DON_FAMILY: "zone-a"
 
     CRE_CLI_WORKFLOW_REGISTRY_ADDRESS: "0x4Ac54353FA4Fa961AfcC5ec4B118596d3305E7e5"
     CRE_CLI_WORKFLOW_REGISTRY_CHAIN_NAME: "ethereum-mainnet"

--- a/internal/environments/environments_test.go
+++ b/internal/environments/environments_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"gopkg.in/yaml.v2"
@@ -142,6 +143,37 @@ func TestNewEnvironmentSet_FallbackAndOverrides(t *testing.T) {
 		t.Errorf("WorkflowRegistryChainName = %q; want ethereum-testnet-arbitrum-1", set3.WorkflowRegistryChainName)
 	}
 
+}
+
+func TestNewEnvironmentSet_DonFamilyFromEnvVarOnly(t *testing.T) {
+	ff := &fileFormat{Envs: map[string]EnvironmentSet{
+		"STAGING": {
+			AuthBase: "https://staging.example",
+		},
+	}}
+
+	t.Setenv(EnvVarDonFamily, "")
+	set := NewEnvironmentSet(ff, "STAGING")
+	if set.DonFamily != "" {
+		t.Errorf("DonFamily = %q; want empty when env var unset", set.DonFamily)
+	}
+
+	t.Setenv(EnvVarDonFamily, "zone-b")
+	set = NewEnvironmentSet(ff, "STAGING")
+	if set.DonFamily != "zone-b" {
+		t.Errorf("DonFamily = %q; want zone-b from env var", set.DonFamily)
+	}
+}
+
+func TestEmbeddedEnvironmentFile_NoDonFamilyDefaults(t *testing.T) {
+	data, err := envFileContent.ReadFile("environments.yaml")
+	if err != nil {
+		t.Fatalf("reading embedded environments file: %v", err)
+	}
+	content := string(data)
+	if strings.Contains(content, "CRE_CLI_DON_FAMILY") {
+		t.Fatal("embedded environments.yaml must not define CRE_CLI_DON_FAMILY")
+	}
 }
 
 func loadEnvironmentFile(path string) (*fileFormat, error) {

--- a/internal/environments/environments_test.go
+++ b/internal/environments/environments_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"gopkg.in/yaml.v2"
@@ -162,17 +161,6 @@ func TestNewEnvironmentSet_DonFamilyFromEnvVarOnly(t *testing.T) {
 	set = NewEnvironmentSet(ff, "STAGING")
 	if set.DonFamily != "zone-b" {
 		t.Errorf("DonFamily = %q; want zone-b from env var", set.DonFamily)
-	}
-}
-
-func TestEmbeddedEnvironmentFile_NoDonFamilyDefaults(t *testing.T) {
-	data, err := envFileContent.ReadFile("environments.yaml")
-	if err != nil {
-		t.Fatalf("reading embedded environments file: %v", err)
-	}
-	content := string(data)
-	if strings.Contains(content, "CRE_CLI_DON_FAMILY") {
-		t.Fatal("embedded environments.yaml must not define CRE_CLI_DON_FAMILY")
 	}
 }
 

--- a/internal/settings/registry_resolution_test.go
+++ b/internal/settings/registry_resolution_test.go
@@ -239,3 +239,22 @@ func TestInterfaceMethods(t *testing.T) {
 	assert.Equal(t, "private", offchain.ID())
 	assert.Equal(t, "zone-b", offchain.DonFamily())
 }
+
+func TestEffectiveDonFamily_TenantDefault(t *testing.T) {
+	envSet := stagingEnvSet()
+	tenantCtx := &tenantctx.EnvironmentContext{DefaultDonFamily: "tenant-zone"}
+	assert.Equal(t, "tenant-zone", EffectiveDonFamily(envSet, tenantCtx))
+}
+
+func TestEffectiveDonFamily_EnvOverridesTenant(t *testing.T) {
+	envSet := stagingEnvSet()
+	envSet.DonFamily = "from-env"
+	tenantCtx := &tenantctx.EnvironmentContext{DefaultDonFamily: "tenant-zone"}
+	assert.Equal(t, "from-env", EffectiveDonFamily(envSet, tenantCtx))
+}
+
+func TestEffectiveDonFamily_EmptyWhenNeitherSet(t *testing.T) {
+	envSet := stagingEnvSet()
+	assert.Equal(t, "", EffectiveDonFamily(envSet, nil))
+	assert.Equal(t, "", EffectiveDonFamily(envSet, &tenantctx.EnvironmentContext{}))
+}

--- a/internal/testutil/chainsim/simulated_environment.go
+++ b/internal/testutil/chainsim/simulated_environment.go
@@ -24,9 +24,10 @@ type SimulatedEnvironment struct {
 	EthClient *seth.Client
 	Contracts *SimulatedContracts
 
-	tenantID  string
-	donFamily string
-	jwtToken  string
+	tenantID           string
+	donFamily          string
+	deploymentRegistry string
+	jwtToken           string
 }
 
 type SimulatedContracts struct {
@@ -55,6 +56,7 @@ func NewSimulatedEnvironment(t *testing.T) *SimulatedEnvironment {
 func (se *SimulatedEnvironment) WithPrivateRegistry(tenantID, donFamily string) *SimulatedEnvironment {
 	se.tenantID = tenantID
 	se.donFamily = donFamily
+	se.deploymentRegistry = "private"
 	return se
 }
 
@@ -77,6 +79,33 @@ func (se *SimulatedEnvironment) Close() {
 	se.Chain.Close()
 }
 
+func testEnvironmentSet(contractAddress string) *environments.EnvironmentSet {
+	return &environments.EnvironmentSet{
+		EnvName:                          environments.StagingEnv,
+		WorkflowRegistryAddress:          contractAddress,
+		WorkflowRegistryChainName:        "ethereum-testnet-sepolia",
+		WorkflowRegistryChainExplorerURL: "https://sepolia.etherscan.io",
+	}
+}
+
+func (se *SimulatedEnvironment) testTenantContext() *tenantctx.EnvironmentContext {
+	tenantID := se.tenantID
+	if tenantID == "" {
+		tenantID = "test-tenant"
+	}
+	return &tenantctx.EnvironmentContext{
+		TenantID:         tenantID,
+		DefaultDonFamily: se.donFamily,
+		Registries: []*tenantctx.Registry{
+			{
+				ID:    "private",
+				Label: "Private (Chainlink-hosted)",
+				Type:  "off-chain",
+			},
+		},
+	}
+}
+
 func (se *SimulatedEnvironment) createContextWithLogger(logger *zerolog.Logger) *runtime.Context {
 	v := viper.New()
 	v.Set(settingspkg.EthPrivateKeyEnvVar, TestPrivateKey)
@@ -87,27 +116,28 @@ func (se *SimulatedEnvironment) createContextWithLogger(logger *zerolog.Logger) 
 
 	simulatedFactory := NewSimulatedClientFactory(logger, se.EthClient, se.Contracts)
 
-	environmentSet, err := environments.New()
-	if err != nil {
-		logger.Warn().Err(err).Msg("failed to create new environment set")
+	environmentSet := testEnvironmentSet(se.Contracts.WorkflowRegistry.Contract.Hex())
+	tenantCtx := se.testTenantContext()
+
+	deploymentRegistry := se.deploymentRegistry
+	if settings != nil {
+		if se.deploymentRegistry != "" {
+			settings.Workflow.UserWorkflowSettings.DeploymentRegistry = se.deploymentRegistry
+		}
+		if settings.Workflow.UserWorkflowSettings.DeploymentRegistry != "" {
+			deploymentRegistry = settings.Workflow.UserWorkflowSettings.DeploymentRegistry
+		}
+	}
+
+	var resolved settingspkg.ResolvedRegistry
+	resolved, resolveErr := settingspkg.ResolveRegistry(deploymentRegistry, tenantCtx, environmentSet)
+	if resolveErr != nil {
+		logger.Warn().Err(resolveErr).Msg("failed to resolve deployment registry")
 	}
 
 	creds, err := credentials.New(logger)
 	if err != nil {
 		logger.Warn().Err(err).Msg("failed to create new credentials")
-	}
-
-	var resolved settingspkg.ResolvedRegistry
-	if se.tenantID != "" {
-		resolved = settingspkg.NewOffChainRegistry("private", se.donFamily)
-	} else if environmentSet != nil {
-		resolved = settingspkg.NewOnChainRegistry(
-			"",
-			se.Contracts.WorkflowRegistry.Contract.Hex(),
-			environmentSet.WorkflowRegistryChainName,
-			environmentSet.DonFamily,
-			environmentSet.WorkflowRegistryChainExplorerURL,
-		)
 	}
 
 	ctx := &runtime.Context{
@@ -118,10 +148,7 @@ func (se *SimulatedEnvironment) createContextWithLogger(logger *zerolog.Logger) 
 		EnvironmentSet:   environmentSet,
 		Credentials:      creds,
 		ResolvedRegistry: resolved,
-	}
-
-	if se.tenantID != "" {
-		ctx.TenantContext = &tenantctx.EnvironmentContext{TenantID: se.tenantID}
+		TenantContext:    tenantCtx,
 	}
 
 	// Mark credentials as validated for tests to bypass validation

--- a/internal/testutil/graphql_mock.go
+++ b/internal/testutil/graphql_mock.go
@@ -34,7 +34,7 @@ func MockGetTenantConfigGraphQLPayload() map[string]any {
 		"data": map[string]any{
 			"getTenantConfig": map[string]any{
 				"tenantId":         "test-tenant-id",
-				"defaultDonFamily": "test-don",
+				"defaultDonFamily": "zone-a",
 				"vaultGatewayUrl":  "https://vault.example.test",
 				"capabilitiesRegistry": map[string]any{
 					"chainSelector": "6433500567565415381",


### PR DESCRIPTION
### Jira
https://smartcontract-it.atlassian.net/browse/DEVSVCS-5161

### Summary:

- Remove hardcoded CRE_CLI_DON_FAMILY: zone-a from embedded environments.yaml (dev/staging/prod)
- Load DonFamily on EnvironmentSet from CRE_CLI_DON_FAMILY env var only
- Precedence: env override → tenantCtx.DefaultDonFamily → empty (validation fails)
- Show DON family in deploy/activate/pause command headers and success output