### PR TITLE
Fix browser secrets failure when default CRE_ETH_PRIVATE_KEY placeholder is set

### DIFF
--- a/cmd/client/eth_client.go
+++ b/cmd/client/eth_client.go
@@ -21,7 +21,6 @@ import (
 	workflow_registry_wrapper "github.com/smartcontractkit/chainlink-evm/gethwrappers/workflow/generated/workflow_registry_wrapper_v2"
 	"github.com/smartcontractkit/chainlink-testing-framework/seth"
 
-	cmdCommon "github.com/smartcontractkit/cre-cli/cmd/common"
 	"github.com/smartcontractkit/cre-cli/internal/constants"
 	"github.com/smartcontractkit/cre-cli/internal/settings"
 )
@@ -81,17 +80,16 @@ func NewEthClientFromEnv(v *viper.Viper, l *zerolog.Logger, ethUrl string) (*set
 	if err != nil {
 		return nil, fmt.Errorf("failed to get chain ID: %w", err)
 	}
-	rawPrivKey := v.GetString(settings.EthPrivateKeyEnvVar)
-	normPrivKey := settings.NormalizeHexKey(rawPrivKey)
+	resolvedKey, err := settings.ResolveEthPrivateKeyFromEnv(v.GetString(settings.EthPrivateKeyEnvVar))
+	if err != nil {
+		return nil, err
+	}
 
 	keys := []string{}
-	if normPrivKey == "" {
+	if !resolvedKey.IsSet() {
 		l.Debug().Msg("No private key provided, all commands that write to chain will work only in unsigned mode")
 	} else {
-		if err := cmdCommon.ValidatePrivateKey(normPrivKey); err != nil {
-			return nil, fmt.Errorf("invalid private key: %w", err)
-		}
-		keys = []string{normPrivKey}
+		keys = []string{resolvedKey.Hex()}
 	}
 
 	client, err := NewSethClient(sethConfigPath, ethUrl, keys, ethChainID)

--- a/cmd/secrets/common/handler.go
+++ b/cmd/secrets/common/handler.go
@@ -96,8 +96,8 @@ type Handler struct {
 func NewHandler(execCtx context.Context, ctx *runtime.Context, secretsFilePath, secretsAuth string) (*Handler, error) {
 	var pk *ecdsa.PrivateKey
 	var err error
-	if ctx.Settings.User.EthPrivateKey != "" {
-		pk, err = crypto.HexToECDSA(ctx.Settings.User.EthPrivateKey)
+	if ctx.Settings.User.EthPrivateKey.IsSet() {
+		pk, err = crypto.HexToECDSA(ctx.Settings.User.EthPrivateKey.Hex())
 		if err != nil {
 			return nil, fmt.Errorf("failed to decode the provided private key: %w", err)
 		}

--- a/cmd/workflow/hash/hash.go
+++ b/cmd/workflow/hash/hash.go
@@ -44,7 +44,6 @@ func New(runtimeContext *runtime.Context) *cobra.Command {
 			s := runtimeContext.Settings
 			v := runtimeContext.Viper
 
-			rawPrivKey := v.GetString(settings.EthPrivateKeyEnvVar)
 			registryType, err := resolveRegistryType(runtimeContext)
 			if err != nil {
 				return err
@@ -57,7 +56,7 @@ func New(runtimeContext *runtime.Context) *cobra.Command {
 				WorkflowName:      s.Workflow.UserWorkflowSettings.WorkflowName,
 				WorkflowPath:      s.Workflow.WorkflowArtifactSettings.WorkflowPath,
 				OwnerFromSettings: s.Workflow.UserWorkflowSettings.WorkflowOwnerAddress,
-				PrivateKey:        settings.NormalizeHexKey(rawPrivKey),
+				PrivateKey:        s.User.EthPrivateKey.Hex(),
 				SkipTypeChecks:    v.GetBool(cmdcommon.SkipTypeChecksCLIFlag),
 				RegistryType:      registryType,
 				DerivedOwner:      runtimeContext.DerivedWorkflowOwner,

--- a/cmd/workflow/simulate/chain/evm/chaintype.go
+++ b/cmd/workflow/simulate/chain/evm/chaintype.go
@@ -221,12 +221,12 @@ func (ct *EVMChainType) RunHealthCheck(resolved chain.ResolvedChains) error {
 // is true, an invalid or default-sentinel key is a hard error. Otherwise a
 // sentinel key is used with a warning so non-broadcast simulations can run.
 func (ct *EVMChainType) ResolveKey(creSettings *settings.Settings, broadcast bool) (interface{}, error) {
-	pk, err := crypto.HexToECDSA(creSettings.User.EthPrivateKey)
+	pk, err := crypto.HexToECDSA(creSettings.User.EthPrivateKey.Hex())
 	if err != nil {
 		// If the user explicitly set a key that looks like a hex string but is
 		// malformed (wrong length, invalid chars), always error with guidance.
-		// Skip placeholder values like "your-eth-private-key" from the default .env template.
-		if creSettings.User.EthPrivateKey != "" && isHexString(creSettings.User.EthPrivateKey) {
+		// Skip placeholder values like DefaultEthPrivateKeyEnvPlaceholder from the default .env template.
+		if creSettings.User.EthPrivateKey.IsSet() && isHexString(creSettings.User.EthPrivateKey.Hex()) {
 			return nil, fmt.Errorf(
 				"invalid private key: expected 64 hex characters (256 bits), got %d characters.\n\n"+
 					"The CLI reads CRE_ETH_PRIVATE_KEY from your .env file or system environment.\n"+
@@ -235,7 +235,7 @@ func (ct *EVMChainType) ResolveKey(creSettings *settings.Settings, broadcast boo
 					"  • Pasted an Ethereum address (40 chars) instead of a private key (64 chars)\n"+
 					"  • Value has extra quotes — use CRE_ETH_PRIVATE_KEY=abc123... without wrapping quotes\n"+
 					"  • Key was truncated during copy-paste",
-				len(creSettings.User.EthPrivateKey))
+				len(creSettings.User.EthPrivateKey.Hex()))
 		}
 		if broadcast {
 			return nil, fmt.Errorf(

--- a/cmd/workflow/simulate/chain/evm/chaintype_test.go
+++ b/cmd/workflow/simulate/chain/evm/chaintype_test.go
@@ -163,7 +163,7 @@ func TestEVMChainType_ResolveKey(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ct := newEVMChainType()
-			s := &settings.Settings{User: settings.UserSettings{EthPrivateKey: tt.pk}}
+			s := &settings.Settings{User: settings.UserSettings{EthPrivateKey: settings.EthPrivateKeyHex(tt.pk)}}
 
 			var got interface{}
 			var err error

--- a/internal/settings/eth_private_key.go
+++ b/internal/settings/eth_private_key.go
@@ -1,0 +1,35 @@
+package settings
+
+import "fmt"
+
+const (
+	// DefaultEthPrivateKeyEnvPlaceholder is written into generated .env files by cre init
+	// and treated as unset when resolving CRE_ETH_PRIVATE_KEY.
+	DefaultEthPrivateKeyEnvPlaceholder = "your-eth-private-key"
+)
+
+// EthPrivateKeyHex holds a normalized ECDSA private key hex string (no 0x prefix).
+// String and GoString redact the value so accidental logging, fmt, or telemetry
+// serialization does not leak the key (e.g. in CI output).
+type EthPrivateKeyHex string
+
+// Hex returns the raw private key hex for cryptographic use.
+func (k EthPrivateKeyHex) Hex() string {
+	return string(k)
+}
+
+// IsSet reports whether a usable private key is present.
+func (k EthPrivateKeyHex) IsSet() bool {
+	return k != ""
+}
+
+func (k EthPrivateKeyHex) String() string {
+	if k == "" {
+		return ""
+	}
+	return "[REDACTED]"
+}
+
+func (k EthPrivateKeyHex) GoString() string {
+	return fmt.Sprintf("settings.EthPrivateKeyHex(%s)", k.String())
+}

--- a/internal/settings/eth_private_key_test.go
+++ b/internal/settings/eth_private_key_test.go
@@ -1,0 +1,24 @@
+package settings_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/smartcontractkit/cre-cli/internal/settings"
+)
+
+func TestEthPrivateKeyHex_RedactedInStringer(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "", settings.EthPrivateKeyHex("").String())
+	assert.Equal(t, "[REDACTED]", settings.EthPrivateKeyHex("ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80").String())
+	assert.Equal(t, "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
+		settings.EthPrivateKeyHex("ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80").Hex())
+}
+
+func TestDefaultEthPrivateKeyEnvPlaceholderUsedInInitTemplate(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, settings.DefaultEthPrivateKeyEnvPlaceholder, "your-eth-private-key")
+}

--- a/internal/settings/eth_private_key_test.go
+++ b/internal/settings/eth_private_key_test.go
@@ -16,9 +16,3 @@ func TestEthPrivateKeyHex_RedactedInStringer(t *testing.T) {
 	assert.Equal(t, "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
 		settings.EthPrivateKeyHex("ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80").Hex())
 }
-
-func TestDefaultEthPrivateKeyEnvPlaceholderUsedInInitTemplate(t *testing.T) {
-	t.Parallel()
-
-	assert.Equal(t, settings.DefaultEthPrivateKeyEnvPlaceholder, "your-eth-private-key")
-}

--- a/internal/settings/private_key_env.go
+++ b/internal/settings/private_key_env.go
@@ -1,0 +1,45 @@
+package settings
+
+import (
+	"strings"
+
+	"github.com/smartcontractkit/cre-cli/internal/ethkeys"
+)
+
+// privateKeyEnvPlaceholders are default template values from cre init that should
+// be treated as unset rather than validated as hex private keys.
+var privateKeyEnvPlaceholders = map[string]struct{}{
+	DefaultEthPrivateKeyEnvPlaceholder: {},
+}
+
+// ResolveEthPrivateKeyFromEnv interprets CRE_ETH_PRIVATE_KEY for settings load.
+// Empty and cre-init placeholder values return ("", nil). Any other non-empty
+// value is validated; malformed keys return an error with guidance. Valid keys
+// return the normalized hex string without a 0x prefix.
+func ResolveEthPrivateKeyFromEnv(raw string) (EthPrivateKeyHex, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", nil
+	}
+	if isPrivateKeyEnvPlaceholder(raw) {
+		return "", nil
+	}
+
+	norm := NormalizeHexKey(raw)
+	if _, err := ethkeys.DeriveEthAddressFromPrivateKey(norm); err != nil {
+		return "", err
+	}
+	return EthPrivateKeyHex(norm), nil
+}
+
+// IsUsablePrivateKeyHex reports whether raw looks like an intentional private key
+// value (non-empty, non-placeholder, valid 64-character hex).
+func IsUsablePrivateKeyHex(raw string) bool {
+	key, err := ResolveEthPrivateKeyFromEnv(raw)
+	return err == nil && key.IsSet()
+}
+
+func isPrivateKeyEnvPlaceholder(s string) bool {
+	_, ok := privateKeyEnvPlaceholders[strings.TrimSpace(s)]
+	return ok
+}

--- a/internal/settings/private_key_env.go
+++ b/internal/settings/private_key_env.go
@@ -32,13 +32,6 @@ func ResolveEthPrivateKeyFromEnv(raw string) (EthPrivateKeyHex, error) {
 	return EthPrivateKeyHex(norm), nil
 }
 
-// IsUsablePrivateKeyHex reports whether raw looks like an intentional private key
-// value (non-empty, non-placeholder, valid 64-character hex).
-func IsUsablePrivateKeyHex(raw string) bool {
-	key, err := ResolveEthPrivateKeyFromEnv(raw)
-	return err == nil && key.IsSet()
-}
-
 func isPrivateKeyEnvPlaceholder(s string) bool {
 	_, ok := privateKeyEnvPlaceholders[strings.TrimSpace(s)]
 	return ok

--- a/internal/settings/private_key_env_test.go
+++ b/internal/settings/private_key_env_test.go
@@ -1,0 +1,82 @@
+package settings_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/cre-cli/internal/settings"
+)
+
+func TestResolveEthPrivateKeyFromEnv(t *testing.T) {
+	t.Parallel()
+
+	validKey := "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+
+	tests := []struct {
+		name    string
+		raw     string
+		want    string
+		wantErr bool
+		errSub  string
+	}{
+		{
+			name: "empty",
+			raw:  "",
+			want: "",
+		},
+		{
+			name: "cre init placeholder",
+			raw:  settings.DefaultEthPrivateKeyEnvPlaceholder,
+			want: "",
+		},
+		{
+			name:    "non-hex template text",
+			raw:     "invalid",
+			wantErr: true,
+			errSub:  "invalid private key: expected 64 hex characters",
+		},
+		{
+			name: "valid key without prefix",
+			raw:  validKey,
+			want: validKey,
+		},
+		{
+			name: "valid key with 0x prefix",
+			raw:  "0x" + validKey,
+			want: validKey,
+		},
+		{
+			name:    "malformed hex length",
+			raw:     strings.Repeat("a", 40),
+			wantErr: true,
+			errSub:  "invalid private key: expected 64 hex characters",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := settings.ResolveEthPrivateKeyFromEnv(tc.raw)
+			if tc.wantErr {
+				require.Error(t, err)
+				if tc.errSub != "" {
+					assert.Contains(t, err.Error(), tc.errSub)
+				}
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, settings.EthPrivateKeyHex(tc.want), got)
+		})
+	}
+}
+
+func TestIsUsablePrivateKeyHex(t *testing.T) {
+	t.Parallel()
+
+	assert.False(t, settings.IsUsablePrivateKeyHex(""))
+	assert.False(t, settings.IsUsablePrivateKeyHex(settings.DefaultEthPrivateKeyEnvPlaceholder))
+	assert.True(t, settings.IsUsablePrivateKeyHex("ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"))
+}

--- a/internal/settings/private_key_env_test.go
+++ b/internal/settings/private_key_env_test.go
@@ -72,11 +72,3 @@ func TestResolveEthPrivateKeyFromEnv(t *testing.T) {
 		})
 	}
 }
-
-func TestIsUsablePrivateKeyHex(t *testing.T) {
-	t.Parallel()
-
-	assert.False(t, settings.IsUsablePrivateKeyHex(""))
-	assert.False(t, settings.IsUsablePrivateKeyHex(settings.DefaultEthPrivateKeyEnvPlaceholder))
-	assert.True(t, settings.IsUsablePrivateKeyHex("ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"))
-}

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -57,7 +57,7 @@ type Settings struct {
 // UserSettings stores user-specific configurations.
 type UserSettings struct {
 	TargetName    string
-	EthPrivateKey string
+	EthPrivateKey EthPrivateKeyHex
 	EthUrl        string
 }
 
@@ -101,8 +101,10 @@ func New(logger *zerolog.Logger, v *viper.Viper, cmd *cobra.Command, registryCha
 		return nil, err
 	}
 
-	rawPrivKey := v.GetString(EthPrivateKeyEnvVar)
-	normPrivKey := NormalizeHexKey(rawPrivKey)
+	normPrivKey, err := ResolveEthPrivateKeyFromEnv(v.GetString(EthPrivateKeyEnvVar))
+	if err != nil {
+		return nil, err
+	}
 
 	return &Settings{
 		User: UserSettings{

--- a/internal/settings/settings_generate.go
+++ b/internal/settings/settings_generate.go
@@ -119,7 +119,7 @@ func GenerateProjectEnvFile(workingDirectory string) (string, error) {
 
 	replacements := map[string]string{
 		"GithubApiToken": "your-github-token",
-		"EthPrivateKey":  "your-eth-private-key",
+		"EthPrivateKey":  DefaultEthPrivateKeyEnvPlaceholder,
 	}
 
 	if err := GenerateFileFromTemplate(outputPath, ProjectEnvironmentTemplateContent, replacements); err != nil {

--- a/internal/settings/settings_generate_test.go
+++ b/internal/settings/settings_generate_test.go
@@ -1,6 +1,7 @@
 package settings
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -10,6 +11,23 @@ import (
 
 	"github.com/smartcontractkit/cre-cli/internal/constants"
 )
+
+func TestProjectEnvTemplateUsesEthPrivateKeyPlaceholder(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	outputPath := filepath.Join(tmpDir, constants.DefaultEnvFileName)
+
+	err := GenerateFileFromTemplate(outputPath, ProjectEnvironmentTemplateContent, map[string]string{
+		"GithubApiToken": "your-github-token",
+		"EthPrivateKey":  DefaultEthPrivateKeyEnvPlaceholder,
+	})
+	require.NoError(t, err)
+
+	content, err := os.ReadFile(outputPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(content), fmt.Sprintf("CRE_ETH_PRIVATE_KEY=%s", DefaultEthPrivateKeyEnvPlaceholder))
+}
 
 func TestBuildRPCsListYAML(t *testing.T) {
 	t.Run("with networks and URLs", func(t *testing.T) {

--- a/internal/settings/settings_get.go
+++ b/internal/settings/settings_get.go
@@ -163,9 +163,17 @@ func GetWorkflowOwner(v *viper.Viper) (ownerAddress string, ownerType string, er
 	}
 
 	// unsigned or changeset is not set, it is EOA path
-	rawPrivKey := v.GetString(EthPrivateKeyEnvVar)
-	normPrivKey := NormalizeHexKey(rawPrivKey)
-	ownerAddress, err = ethkeys.DeriveEthAddressFromPrivateKey(normPrivKey)
+	normPrivKey, err := ResolveEthPrivateKeyFromEnv(v.GetString(EthPrivateKeyEnvVar))
+	if err != nil {
+		return "", "", err
+	}
+	if normPrivKey == "" {
+		return "", "", fmt.Errorf(
+			"%s is not set. Set it in your .env file or export it in your shell environment",
+			EthPrivateKeyEnvVar,
+		)
+	}
+	ownerAddress, err = ethkeys.DeriveEthAddressFromPrivateKey(normPrivKey.Hex())
 	if err != nil {
 		return "", "", err
 	}

--- a/internal/settings/settings_get_test.go
+++ b/internal/settings/settings_get_test.go
@@ -25,13 +25,38 @@ func TestGetWorkflowOwner(t *testing.T) {
 		assert.Equal(t, constants.WorkflowOwnerTypeEOA, ownerType)
 	})
 
-	t.Run("returns error for invalid eth private key", func(t *testing.T) {
+	t.Run("returns error for non-hex private key", func(t *testing.T) {
 		v := viper.New()
 		v.Set(settings.CreTargetEnvVar, "test")
 		v.Set(settings.EthPrivateKeyEnvVar, "invalid")
 
 		owner, ownerType, err := settings.GetWorkflowOwner(v)
 		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid private key: expected 64 hex characters")
+		assert.Equal(t, "", owner)
+		assert.Equal(t, "", ownerType)
+	})
+
+	t.Run("returns error for cre init placeholder", func(t *testing.T) {
+		v := viper.New()
+		v.Set(settings.CreTargetEnvVar, "test")
+		v.Set(settings.EthPrivateKeyEnvVar, settings.DefaultEthPrivateKeyEnvPlaceholder)
+
+		owner, ownerType, err := settings.GetWorkflowOwner(v)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "CRE_ETH_PRIVATE_KEY is not set")
+		assert.Equal(t, "", owner)
+		assert.Equal(t, "", ownerType)
+	})
+
+	t.Run("returns error for malformed hex private key", func(t *testing.T) {
+		v := viper.New()
+		v.Set(settings.CreTargetEnvVar, "test")
+		v.Set(settings.EthPrivateKeyEnvVar, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+
+		owner, ownerType, err := settings.GetWorkflowOwner(v)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid private key: expected 64 hex characters")
 		assert.Equal(t, "", owner)
 		assert.Equal(t, "", ownerType)
 	})

--- a/internal/settings/settings_test.go
+++ b/internal/settings/settings_test.go
@@ -136,7 +136,33 @@ func TestLoadEnvAndSettings(t *testing.T) {
 	s, err := settings.New(logger, v, cmd, "")
 	require.NoError(t, err)
 	assert.Equal(t, "staging", s.User.TargetName)
-	assert.Equal(t, "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80", s.User.EthPrivateKey)
+	assert.Equal(t, settings.EthPrivateKeyHex("ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"), s.User.EthPrivateKey)
+}
+
+func TestLoadEnvAndSettingsCreInitPlaceholderPrivateKey(t *testing.T) {
+	envVars := map[string]string{
+		settings.CreTargetEnvVar:     "staging",
+		settings.EthPrivateKeyEnvVar: settings.DefaultEthPrivateKeyEnvPlaceholder,
+	}
+
+	workflowTemplatePath, err := filepath.Abs(TempWorkflowSettingsFile)
+	require.NoError(t, err)
+
+	projectTemplatePath, err := filepath.Abs(TempProjectSettingsFile)
+	require.NoError(t, err)
+
+	tempDir := t.TempDir()
+	restoreWorkingDirectory, err := testutil.ChangeWorkingDirectory(tempDir)
+	require.NoError(t, err)
+	defer restoreWorkingDirectory()
+
+	v, logger := createTestContext(t, envVars, tempDir)
+
+	setUpTestSettingsFiles(t, v, workflowTemplatePath, projectTemplatePath, tempDir)
+	cmd := makeCmdWithSecretsAuth("create", "browser")
+	s, err := settings.New(logger, v, cmd, "")
+	require.NoError(t, err)
+	assert.Empty(t, s.User.EthPrivateKey)
 }
 
 func TestLoadEnvAndSettingsWithWorkflowSettingsFlag(t *testing.T) {
@@ -169,7 +195,7 @@ func TestLoadEnvAndSettingsWithWorkflowSettingsFlag(t *testing.T) {
 	s, err := settings.New(logger, v, cmd, "")
 	require.NoError(t, err)
 	assert.Equal(t, "staging", s.User.TargetName)
-	assert.Equal(t, "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80", s.User.EthPrivateKey)
+	assert.Equal(t, settings.EthPrivateKeyHex("ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"), s.User.EthPrivateKey)
 }
 
 func TestInlineEnvTakesPrecedenceOverDotEnv(t *testing.T) {
@@ -199,7 +225,7 @@ func TestInlineEnvTakesPrecedenceOverDotEnv(t *testing.T) {
 	s, err := settings.New(logger, v, cmd, "")
 	require.NoError(t, err)
 	assert.Equal(t, "staging", s.User.TargetName)
-	assert.Equal(t, "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80", s.User.EthPrivateKey)
+	assert.Equal(t, settings.EthPrivateKeyHex("ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"), s.User.EthPrivateKey)
 }
 
 func TestLoadEnvAndMergedSettings(t *testing.T) {
@@ -241,7 +267,7 @@ func TestLoadEnvAndMergedSettings(t *testing.T) {
 	rpc2 := s.Workflow.RPCs[1]
 	assert.Equal(t, "https://somethingElse.rpc.org", rpc1.Url, "First RPC URL mismatch")
 	assert.Equal(t, "https://something.rpc.org", rpc2.Url, "Second RPC URL mismatch")
-	assert.Equal(t, "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80", s.User.EthPrivateKey)
+	assert.Equal(t, settings.EthPrivateKeyHex("ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"), s.User.EthPrivateKey)
 }
 
 // helper to build a command with optional --broadcast flag and parse args


### PR DESCRIPTION
### JIRA
https://smartcontract-it.atlassian.net/browse/DEVSVCS-5190
### Summary
- Treat the cre-init placeholder (your-eth-private-key) and empty values as unset so browser-auth secrets commands no longer fail on decode
- Add ResolveEthPrivateKeyFromEnv to centralize validation at settings load; invalid non-placeholder values return a clear hex-length error
- Introduce EthPrivateKeyHex with redacted String()/GoString() and explicit .Hex() accessor to reduce accidental key leakage
- Update secrets handler and EVM simulate to use .IsSet()/.Hex() instead of raw string checks
- Share placeholder constant between .env generation and resolution logic