### PR TITLE
Enable browser OAuth secrets auth in production

### DIFF
--- a/cmd/secrets/common/validate.go
+++ b/cmd/secrets/common/validate.go
@@ -1,25 +1,16 @@
 package common
 
-import (
-	"fmt"
-	"strings"
-)
+import "fmt"
 
 const (
 	SecretsAuthOnchain = "onchain"
 	SecretsAuthBrowser = "browser"
 )
 
-// ValidateSecretsAuthFlow checks that the chosen auth flow is valid and
-// allowed in the current environment. Browser flow is blocked in production.
-func ValidateSecretsAuthFlow(flow, envName string) error {
+// ValidateSecretsAuthFlow checks that the chosen auth flow is valid.
+func ValidateSecretsAuthFlow(flow string) error {
 	switch flow {
-	case SecretsAuthOnchain:
-		return nil
-	case SecretsAuthBrowser:
-		if strings.EqualFold(envName, "PRODUCTION") || envName == "" {
-			return fmt.Errorf("browser auth flow is not yet available in production; use --secrets-auth=onchain")
-		}
+	case SecretsAuthOnchain, SecretsAuthBrowser:
 		return nil
 	default:
 		return fmt.Errorf("unknown --secrets-auth value %q; expected %q or %q", flow, SecretsAuthOnchain, SecretsAuthBrowser)

--- a/cmd/secrets/common/validate_test.go
+++ b/cmd/secrets/common/validate_test.go
@@ -1,7 +1,6 @@
 package common
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -12,32 +11,21 @@ func TestValidateSecretsAuthFlow(t *testing.T) {
 	tests := []struct {
 		name    string
 		flow    string
-		env     string
 		wantErr bool
 		errMsg  string
 	}{
-		{"onchain in production", SecretsAuthOnchain, "PRODUCTION", false, ""},
-		{"onchain in staging", SecretsAuthOnchain, "STAGING", false, ""},
-		{"onchain in dev", SecretsAuthOnchain, "DEVELOPMENT", false, ""},
-		{"onchain empty env defaults safe", SecretsAuthOnchain, "", false, ""},
-		{"browser in staging", SecretsAuthBrowser, "STAGING", false, ""},
-		{"browser in dev", SecretsAuthBrowser, "DEVELOPMENT", false, ""},
-		{"browser in production blocked", SecretsAuthBrowser, "PRODUCTION", true, "not yet available in production"},
-		{"browser in production lowercase", SecretsAuthBrowser, "production", true, "not yet available in production"},
-		{"browser empty env treated as production", SecretsAuthBrowser, "", true, "not yet available in production"},
-		{"unknown value rejected", "magic", "STAGING", true, "unknown --secrets-auth value"},
+		{"onchain", SecretsAuthOnchain, false, ""},
+		{"browser", SecretsAuthBrowser, false, ""},
+		{"unknown value rejected", "magic", true, "unknown --secrets-auth value"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := ValidateSecretsAuthFlow(tt.flow, tt.env)
+			err := ValidateSecretsAuthFlow(tt.flow)
 			if tt.wantErr {
 				require.Error(t, err)
 				if tt.errMsg != "" {
 					require.Contains(t, err.Error(), tt.errMsg)
-				}
-				if strings.Contains(tt.name, "browser") && strings.Contains(tt.name, "production") {
-					require.Contains(t, err.Error(), "use --secrets-auth=onchain")
 				}
 			} else {
 				require.NoError(t, err)

--- a/cmd/secrets/create/create.go
+++ b/cmd/secrets/create/create.go
@@ -37,7 +37,7 @@ func New(ctx *runtime.Context) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			if err := common.ValidateSecretsAuthFlow(secretsAuth, ctx.EnvironmentSet.EnvName); err != nil {
+			if err := common.ValidateSecretsAuthFlow(secretsAuth); err != nil {
 				return err
 			}
 

--- a/cmd/secrets/delete/delete.go
+++ b/cmd/secrets/delete/delete.go
@@ -70,7 +70,7 @@ func New(ctx *runtime.Context) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			if err := common.ValidateSecretsAuthFlow(secretsAuth, ctx.EnvironmentSet.EnvName); err != nil {
+			if err := common.ValidateSecretsAuthFlow(secretsAuth); err != nil {
 				return err
 			}
 

--- a/cmd/secrets/list/list.go
+++ b/cmd/secrets/list/list.go
@@ -48,7 +48,7 @@ func New(ctx *runtime.Context) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			if err := common.ValidateSecretsAuthFlow(secretsAuth, ctx.EnvironmentSet.EnvName); err != nil {
+			if err := common.ValidateSecretsAuthFlow(secretsAuth); err != nil {
 				return err
 			}
 

--- a/cmd/secrets/update/update.go
+++ b/cmd/secrets/update/update.go
@@ -37,7 +37,7 @@ func New(ctx *runtime.Context) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			if err := common.ValidateSecretsAuthFlow(secretsAuth, ctx.EnvironmentSet.EnvName); err != nil {
+			if err := common.ValidateSecretsAuthFlow(secretsAuth); err != nil {
 				return err
 			}
 


### PR DESCRIPTION
[DEVSVCS-5084](https://smartcontract-it.atlassian.net/browse/DEVSVCS-5084)

## Summary
- Remove the production environment gate that blocked `--secrets-auth=browser` on secrets commands
- Simplify `ValidateSecretsAuthFlow` to only validate the auth mode value (`onchain` / `browser`), dropping the unused `envName` parameter
- Update create, update, delete, and list command call sites and tests accordingly
