### PR TITLE
Fix CleanLogMessage

### DIFF
--- a/cmd/workflow/simulate/simulate_logger.go
+++ b/cmd/workflow/simulate/simulate_logger.go
@@ -249,20 +249,18 @@ func CleanLogMessage(msg string) string {
 	// Common patterns: time=..., timestamp=..., ts=..., level=...
 	msg = strings.TrimSpace(msg)
 
-	// Remove time=... patterns
-	timePattern := regexp.MustCompile(`time=\S+\s*`)
+	// Anchor on word-boundary so we don't eat substrings inside user words
+	// (e.g. `lamports=<n>` was getting its `ts=<n>` portion stripped).
+	timePattern := regexp.MustCompile(`\btime=\S+\s*`)
 	msg = timePattern.ReplaceAllString(msg, "")
 
-	// Remove timestamp=... patterns
-	timestampPattern := regexp.MustCompile(`timestamp=\S+\s*`)
+	timestampPattern := regexp.MustCompile(`\btimestamp=\S+\s*`)
 	msg = timestampPattern.ReplaceAllString(msg, "")
 
-	// Remove ts=... patterns
-	tsPattern := regexp.MustCompile(`ts=\S+\s*`)
+	tsPattern := regexp.MustCompile(`\bts=\S+\s*`)
 	msg = tsPattern.ReplaceAllString(msg, "")
 
-	// Remove level=... patterns
-	levelPattern := regexp.MustCompile(`level=\S+\s*`)
+	levelPattern := regexp.MustCompile(`\blevel=\S+\s*`)
 	msg = levelPattern.ReplaceAllString(msg, "")
 
 	return strings.TrimSpace(msg)


### PR DESCRIPTION
Agent:

The intent is fine; the implementation was sloppy — no word boundary, so ts= matched inside lamports=, assets=, events=, metrics=, anywhere …ts= shows up as a substring. Same risk exists for level= (anything ending in level=, e.g. loglevel=), but ts= is the worst offender because it's only 3 characters and -rts$ / -ets$ / -its$ word endings are common.

The \b fix anchors each pattern to start at a word boundary — so only standalone ts=... fields get stripped, not substrings buried inside user content.

```
echo "lamports=5000000000" | grep -oE 'ts=\S+'
# prints: ts=5000000000   ← yep, that's what was getting stripped
```
