### PR TITLE
[DEVSVCS-5278] Harden `cre update`

### DIFF
--- a/cmd/update/update.go
+++ b/cmd/update/update.go
@@ -57,7 +57,7 @@ func getLatestTag() (string, error) {
 	return info.TagName, nil
 }
 
-func getAssetName() (asset string, platform string, err error) {
+func getAssetName() (asset string, platform string, archName string, err error) {
 	osName := osruntime.GOOS
 	arch := osruntime.GOARCH
 	var ext string
@@ -72,9 +72,8 @@ func getAssetName() (asset string, platform string, err error) {
 		platform = "windows"
 		ext = ".zip"
 	default:
-		return "", "", fmt.Errorf("unsupported OS: %s", osName)
+		return "", "", "", fmt.Errorf("unsupported OS: %s", osName)
 	}
-	var archName string
 	switch arch {
 	case "amd64", "x86_64":
 		archName = "amd64"
@@ -85,10 +84,10 @@ func getAssetName() (asset string, platform string, err error) {
 			archName = "arm64"
 		}
 	default:
-		return "", "", fmt.Errorf("unsupported architecture: %s", arch)
+		return "", "", "", fmt.Errorf("unsupported architecture: %s", arch)
 	}
 	asset = fmt.Sprintf("%s_%s_%s%s", cliName, platform, archName, ext)
-	return asset, platform, nil
+	return asset, platform, archName, nil
 }
 
 func downloadFile(url, dest, message string) error {
@@ -336,7 +335,7 @@ func Run(currentVersion string) error {
 	}
 
 	// If we're here, an update is needed.
-	asset, _, err := getAssetName()
+	asset, platform, archName, err := getAssetName()
 	if err != nil {
 		spinner.Stop()
 		return fmt.Errorf("error determining asset name: %w", err)
@@ -366,6 +365,24 @@ func Run(currentVersion string) error {
 	if err != nil {
 		spinner.Stop()
 		return fmt.Errorf("extraction failed: %w", err)
+	}
+
+	var sigPath string
+	if platform == "linux" {
+		sigAsset := getSigAssetName(platform, archName)
+		sigPath = filepath.Join(tmpDir, sigAsset)
+		sigURL := fmt.Sprintf("https://github.com/%s/releases/download/%s/%s", repo, tag, sigAsset)
+		sigDownloadMsg := fmt.Sprintf("Downloading signature for %s...", tag)
+		if err := downloadFile(sigURL, sigPath, sigDownloadMsg); err != nil {
+			spinner.Stop()
+			return fmt.Errorf("signature download failed: %w", err)
+		}
+	}
+
+	spinner.Update("Verifying release signature...")
+	if err := verifyReleaseBinary(binPath, sigPath); err != nil {
+		spinner.Stop()
+		return fmt.Errorf("release signature verification failed: %w", err)
 	}
 
 	spinner.Update("Installing...")

--- a/cmd/update/update.go
+++ b/cmd/update/update.go
@@ -413,6 +413,13 @@ func New(_ *runtime.Context) *cobra.Command { // <-- No longer uses rt
 	var versionCmd = &cobra.Command{
 		Use:   "update",
 		Short: "Update the cre CLI to the latest version",
+		Long: `Update the cre CLI to the latest version
+
+Release signatures are verified using the public key published by the CRE team.
+
+On Linux, the signature is verified using GPG.
+On macOS, the signature is verified using codesign.
+On Windows, the signature is verified using Authenticode.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return Run(version.Version)
 		},

--- a/cmd/update/update_test.go
+++ b/cmd/update/update_test.go
@@ -1,0 +1,88 @@
+package update
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"bytes"
+	"compress/gzip"
+	"encoding/json"
+	"net/http"
+	"path/filepath"
+	"testing"
+
+	"github.com/jarcoal/httpmock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRun_abortsWhenSignatureVerificationFails(t *testing.T) {
+	httpmock.ActivateNonDefault(httpClient)
+	t.Cleanup(httpmock.DeactivateAndReset)
+
+	asset, platform, archName, err := getAssetName()
+	require.NoError(t, err)
+
+	tag := "v99.0.0-test"
+	httpmock.RegisterResponder("GET", "https://api.github.com/repos/smartcontractkit/cre-cli/releases/latest",
+		func(_ *http.Request) (*http.Response, error) {
+			body, _ := json.Marshal(releaseInfo{TagName: tag})
+			return httpmock.NewBytesResponse(http.StatusOK, body), nil
+		},
+	)
+
+	archiveBytes := createTestArchiveBytes(t, asset, tag, platform, archName, []byte("#!/bin/sh\necho test\n"))
+
+	downloadURL := "https://github.com/smartcontractkit/cre-cli/releases/download/" + tag + "/" + asset
+	httpmock.RegisterResponder("GET", downloadURL,
+		func(_ *http.Request) (*http.Response, error) {
+			return httpmock.NewBytesResponse(http.StatusOK, archiveBytes), nil
+		},
+	)
+
+	if platform == "linux" {
+		sigAsset := getSigAssetName(platform, archName)
+		sigURL := "https://github.com/smartcontractkit/cre-cli/releases/download/" + tag + "/" + sigAsset
+		httpmock.RegisterResponder("GET", sigURL,
+			func(_ *http.Request) (*http.Response, error) {
+				return httpmock.NewBytesResponse(http.StatusOK, []byte("invalid-signature")), nil
+			},
+		)
+	}
+
+	err = Run("version v0.0.1")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "release signature verification failed")
+}
+
+func createTestArchiveBytes(t *testing.T, asset, tag, platform, archName string, content []byte) []byte {
+	t.Helper()
+	binName := "cre_" + tag + "_" + platform + "_" + archName
+	if platform == "windows" {
+		binName += ".exe"
+	}
+
+	if filepath.Ext(asset) == ".zip" {
+		buf := &bytes.Buffer{}
+		zw := zip.NewWriter(buf)
+		w, err := zw.Create(binName)
+		require.NoError(t, err)
+		_, err = w.Write(content)
+		require.NoError(t, err)
+		require.NoError(t, zw.Close())
+		return buf.Bytes()
+	}
+
+	buf := &bytes.Buffer{}
+	gz := gzip.NewWriter(buf)
+	tw := tar.NewWriter(gz)
+	hdr := &tar.Header{
+		Name: binName,
+		Mode: 0755,
+		Size: int64(len(content)),
+	}
+	require.NoError(t, tw.WriteHeader(hdr))
+	_, err := tw.Write(content)
+	require.NoError(t, err)
+	require.NoError(t, tw.Close())
+	require.NoError(t, gz.Close())
+	return buf.Bytes()
+}

--- a/cmd/update/verify.go
+++ b/cmd/update/verify.go
@@ -4,8 +4,6 @@ const (
 	expectedSignerName  = "CRE"
 	expectedSignerEmail = "cre@smartcontract.com"
 	codesignIdentifier  = "com.smartcontract.cre.cli"
-	// windowsSignerSubject is a substring of the Authenticode certificate subject.
-	windowsSignerSubject = "Smart Contract"
 )
 
 func getSigAssetName(platform, archName string) string {

--- a/cmd/update/verify.go
+++ b/cmd/update/verify.go
@@ -1,0 +1,13 @@
+package update
+
+const (
+	expectedSignerName  = "CRE"
+	expectedSignerEmail = "cre@smartcontract.com"
+	codesignIdentifier  = "com.smartcontract.cre.cli"
+	// windowsSignerSubject is a substring of the Authenticode certificate subject.
+	windowsSignerSubject = "Smart Contract"
+)
+
+func getSigAssetName(platform, archName string) string {
+	return "cre_" + platform + "_" + archName + ".sig"
+}

--- a/cmd/update/verify_darwin.go
+++ b/cmd/update/verify_darwin.go
@@ -1,0 +1,24 @@
+//go:build darwin
+
+package update
+
+import (
+	"bytes"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+func verifyReleaseBinary(binPath, _ string) error {
+	cmd := exec.Command("codesign", "--verify", "--strict", "--identifier", codesignIdentifier, binPath) // #nosec G204 -- fixed args, user-controlled path only
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		msg := strings.TrimSpace(stderr.String())
+		if msg != "" {
+			return fmt.Errorf("codesign verification failed: %s: %w", msg, err)
+		}
+		return fmt.Errorf("codesign verification failed: %w", err)
+	}
+	return nil
+}

--- a/cmd/update/verify_linux.go
+++ b/cmd/update/verify_linux.go
@@ -1,0 +1,93 @@
+//go:build linux
+
+package update
+
+import (
+	"bytes"
+	_ "embed"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"golang.org/x/crypto/openpgp"
+	"golang.org/x/crypto/openpgp/armor"
+)
+
+//go:embed ../../install/public_key.asc
+var releasePublicKey []byte
+
+func verifyReleaseBinary(binPath, sigPath string) error {
+	if sigPath == "" {
+		return fmt.Errorf("missing signature file path")
+	}
+	return verifyGPGSignature(releasePublicKey, binPath, sigPath)
+}
+
+func verifyGPGSignature(publicKey []byte, binPath, sigPath string) error {
+	keyring, err := openpgp.ReadArmoredKeyRing(bytes.NewReader(publicKey))
+	if err != nil {
+		return fmt.Errorf("parse release public key: %w", err)
+	}
+
+	signed, err := os.Open(binPath) // #nosec G703 -- path from controlled temp extraction
+	if err != nil {
+		return fmt.Errorf("open binary: %w", err)
+	}
+	defer signed.Close()
+
+	sigBytes, err := os.ReadFile(sigPath) // #nosec G703 -- path from controlled temp download
+	if err != nil {
+		return fmt.Errorf("read signature: %w", err)
+	}
+
+	entity, err := checkDetachedSignature(keyring, signed, sigBytes)
+	if err != nil {
+		return fmt.Errorf("GPG signature invalid: %w", err)
+	}
+
+	if err := validateSignerIdentity(entity); err != nil {
+		return err
+	}
+	return nil
+}
+
+func checkDetachedSignature(keyring openpgp.KeyRing, signed *os.File, sigBytes []byte) (*openpgp.Entity, error) {
+	if _, err := signed.Seek(0, io.SeekStart); err != nil {
+		return nil, fmt.Errorf("rewind binary: %w", err)
+	}
+
+	sigReader := bytes.NewReader(sigBytes)
+	if block, _ := armor.Decode(sigReader); block != nil {
+		if _, err := signed.Seek(0, io.SeekStart); err != nil {
+			return nil, fmt.Errorf("rewind binary: %w", err)
+		}
+		entity, err := openpgp.CheckDetachedSignature(keyring, signed, block.Body)
+		if err != nil {
+			return nil, err
+		}
+		return entity, nil
+	}
+
+	if _, err := signed.Seek(0, io.SeekStart); err != nil {
+		return nil, fmt.Errorf("rewind binary: %w", err)
+	}
+	entity, err := openpgp.CheckArmoredDetachedSignature(keyring, signed, bytes.NewReader(sigBytes))
+	if err != nil {
+		return nil, err
+	}
+	return entity, nil
+}
+
+func validateSignerIdentity(entity *openpgp.Entity) error {
+	if entity == nil {
+		return fmt.Errorf("missing signer identity")
+	}
+	for _, identity := range entity.Identities {
+		if strings.Contains(identity.Name, expectedSignerName) &&
+			strings.EqualFold(identity.Email, expectedSignerEmail) {
+			return nil
+		}
+	}
+	return fmt.Errorf("unexpected signer identity")
+}

--- a/cmd/update/verify_linux.go
+++ b/cmd/update/verify_linux.go
@@ -4,24 +4,21 @@ package update
 
 import (
 	"bytes"
-	_ "embed"
 	"fmt"
 	"io"
 	"os"
 	"strings"
 
+	"github.com/smartcontractkit/cre-cli/install"
 	"golang.org/x/crypto/openpgp"
 	"golang.org/x/crypto/openpgp/armor"
 )
-
-//go:embed ../../install/public_key.asc
-var releasePublicKey []byte
 
 func verifyReleaseBinary(binPath, sigPath string) error {
 	if sigPath == "" {
 		return fmt.Errorf("missing signature file path")
 	}
-	return verifyGPGSignature(releasePublicKey, binPath, sigPath)
+	return verifyGPGSignature(install.ReleasePublicKey, binPath, sigPath)
 }
 
 func verifyGPGSignature(publicKey []byte, binPath, sigPath string) error {
@@ -84,8 +81,12 @@ func validateSignerIdentity(entity *openpgp.Entity) error {
 		return fmt.Errorf("missing signer identity")
 	}
 	for _, identity := range entity.Identities {
+		email := ""
+		if identity.UserId != nil {
+			email = identity.UserId.Email
+		}
 		if strings.Contains(identity.Name, expectedSignerName) &&
-			strings.EqualFold(identity.Email, expectedSignerEmail) {
+			strings.EqualFold(email, expectedSignerEmail) {
 			return nil
 		}
 	}

--- a/cmd/update/verify_linux.go
+++ b/cmd/update/verify_linux.go
@@ -1,5 +1,6 @@
 //go:build linux
 
+//nolint:staticcheck // SA1019: OpenPGP required to verify KMS GPG release signatures.
 package update
 
 import (
@@ -9,9 +10,10 @@ import (
 	"os"
 	"strings"
 
-	"github.com/smartcontractkit/cre-cli/install"
 	"golang.org/x/crypto/openpgp"
 	"golang.org/x/crypto/openpgp/armor"
+
+	"github.com/smartcontractkit/cre-cli/install"
 )
 
 func verifyReleaseBinary(binPath, sigPath string) error {
@@ -43,10 +45,7 @@ func verifyGPGSignature(publicKey []byte, binPath, sigPath string) error {
 		return fmt.Errorf("GPG signature invalid: %w", err)
 	}
 
-	if err := validateSignerIdentity(entity); err != nil {
-		return err
-	}
-	return nil
+	return validateSignerIdentity(entity)
 }
 
 func checkDetachedSignature(keyring openpgp.KeyRing, signed *os.File, sigBytes []byte) (*openpgp.Entity, error) {

--- a/cmd/update/verify_linux_test.go
+++ b/cmd/update/verify_linux_test.go
@@ -1,0 +1,118 @@
+//go:build linux
+
+package update
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/openpgp"
+	"golang.org/x/crypto/openpgp/armor"
+)
+
+func TestVerifyGPGSignature_validSignature(t *testing.T) {
+	entity, err := openpgp.NewEntity("CRE", "Linux GPG Signing Key", "cre@smartcontract.com", nil)
+	require.NoError(t, err)
+
+	tmpDir := t.TempDir()
+	binPath := filepath.Join(tmpDir, "cre")
+	content := []byte("test-binary-content")
+	require.NoError(t, os.WriteFile(binPath, content, 0600))
+
+	sigPath := filepath.Join(tmpDir, "cre.sig")
+	require.NoError(t, writeArmoredDetachedSignature(sigPath, entity, content))
+
+	pubKey, err := exportPublicKey(entity)
+	require.NoError(t, err)
+
+	require.NoError(t, verifyGPGSignature(pubKey, binPath, sigPath))
+}
+
+func TestVerifyGPGSignature_tamperedBinary(t *testing.T) {
+	entity, err := openpgp.NewEntity("CRE", "Linux GPG Signing Key", "cre@smartcontract.com", nil)
+	require.NoError(t, err)
+
+	tmpDir := t.TempDir()
+	binPath := filepath.Join(tmpDir, "cre")
+	require.NoError(t, os.WriteFile(binPath, []byte("original"), 0600))
+
+	sigPath := filepath.Join(tmpDir, "cre.sig")
+	require.NoError(t, writeArmoredDetachedSignature(sigPath, entity, []byte("original")))
+
+	pubKey, err := exportPublicKey(entity)
+	require.NoError(t, err)
+
+	require.NoError(t, os.WriteFile(binPath, []byte("tampered"), 0600))
+	err = verifyGPGSignature(pubKey, binPath, sigPath)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "GPG signature invalid")
+}
+
+func TestVerifyGPGSignature_unexpectedSigner(t *testing.T) {
+	entity, err := openpgp.NewEntity("Other", "Signer", "other@example.com", nil)
+	require.NoError(t, err)
+
+	tmpDir := t.TempDir()
+	binPath := filepath.Join(tmpDir, "cre")
+	content := []byte("test-binary-content")
+	require.NoError(t, os.WriteFile(binPath, content, 0600))
+
+	sigPath := filepath.Join(tmpDir, "cre.sig")
+	require.NoError(t, writeArmoredDetachedSignature(sigPath, entity, content))
+
+	pubKey, err := exportPublicKey(entity)
+	require.NoError(t, err)
+
+	err = verifyGPGSignature(pubKey, binPath, sigPath)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unexpected signer identity")
+}
+
+func TestVerifyGPGSignature_embeddedReleaseKeyParses(t *testing.T) {
+	require.NotEmpty(t, releasePublicKey)
+	_, err := openpgp.ReadArmoredKeyRing(bytes.NewReader(releasePublicKey))
+	require.NoError(t, err)
+}
+
+func writeArmoredDetachedSignature(path string, entity *openpgp.Entity, content []byte) error {
+	var sigBuf bytes.Buffer
+	armorWriter, err := armor.Encode(&sigBuf, openpgp.SignatureType, nil)
+	if err != nil {
+		return err
+	}
+	if err := openpgp.DetachSign(armorWriter, entity, bytes.NewReader(content), nil); err != nil {
+		return err
+	}
+	if err := armorWriter.Close(); err != nil {
+		return err
+	}
+	return os.WriteFile(path, sigBuf.Bytes(), 0600)
+}
+
+func exportPublicKey(entity *openpgp.Entity) ([]byte, error) {
+	var buf bytes.Buffer
+	armorWriter, err := armor.Encode(&buf, openpgp.PublicKeyType, nil)
+	if err != nil {
+		return nil, err
+	}
+	if err := entity.Serialize(armorWriter); err != nil {
+		return nil, err
+	}
+	if err := armorWriter.Close(); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+func TestValidateSignerIdentity(t *testing.T) {
+	validEntity, err := openpgp.NewEntity("CRE", "Linux GPG Signing Key", "cre@smartcontract.com", nil)
+	require.NoError(t, err)
+	require.NoError(t, validateSignerIdentity(validEntity))
+
+	invalidEntity, err := openpgp.NewEntity("Evil", "Signer", "evil@example.com", nil)
+	require.NoError(t, err)
+	require.Error(t, validateSignerIdentity(invalidEntity))
+}

--- a/cmd/update/verify_linux_test.go
+++ b/cmd/update/verify_linux_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/smartcontractkit/cre-cli/install"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/openpgp"
 	"golang.org/x/crypto/openpgp/armor"
@@ -72,8 +73,8 @@ func TestVerifyGPGSignature_unexpectedSigner(t *testing.T) {
 }
 
 func TestVerifyGPGSignature_embeddedReleaseKeyParses(t *testing.T) {
-	require.NotEmpty(t, releasePublicKey)
-	_, err := openpgp.ReadArmoredKeyRing(bytes.NewReader(releasePublicKey))
+	require.NotEmpty(t, install.ReleasePublicKey)
+	_, err := openpgp.ReadArmoredKeyRing(bytes.NewReader(install.ReleasePublicKey))
 	require.NoError(t, err)
 }
 

--- a/cmd/update/verify_linux_test.go
+++ b/cmd/update/verify_linux_test.go
@@ -1,5 +1,6 @@
 //go:build linux
 
+//nolint:staticcheck // SA1019: OpenPGP required to verify KMS GPG release signatures.
 package update
 
 import (
@@ -8,10 +9,11 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/smartcontractkit/cre-cli/install"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/openpgp"
 	"golang.org/x/crypto/openpgp/armor"
+
+	"github.com/smartcontractkit/cre-cli/install"
 )
 
 func TestVerifyGPGSignature_validSignature(t *testing.T) {

--- a/cmd/update/verify_test.go
+++ b/cmd/update/verify_test.go
@@ -5,8 +5,9 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/smartcontractkit/cre-cli/install"
 	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/cre-cli/install"
 )
 
 func TestReleasePublicKeyMatchesInstall(t *testing.T) {

--- a/cmd/update/verify_test.go
+++ b/cmd/update/verify_test.go
@@ -1,0 +1,21 @@
+package update
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetSigAssetName(t *testing.T) {
+	require.Equal(t, "cre_linux_amd64.sig", getSigAssetName("linux", "amd64"))
+	require.Equal(t, "cre_darwin_arm64.sig", getSigAssetName("darwin", "arm64"))
+}
+
+func TestGetAssetName(t *testing.T) {
+	asset, platform, archName, err := getAssetName()
+	require.NoError(t, err)
+	require.NotEmpty(t, asset)
+	require.NotEmpty(t, platform)
+	require.NotEmpty(t, archName)
+	require.Contains(t, asset, "cre_"+platform+"_"+archName)
+}

--- a/cmd/update/verify_test.go
+++ b/cmd/update/verify_test.go
@@ -1,28 +1,13 @@
 package update
 
 import (
-	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
-
-	"github.com/smartcontractkit/cre-cli/install"
 )
-
-func TestReleasePublicKeyMatchesInstall(t *testing.T) {
-	embedded := install.ReleasePublicKey
-	require.NotEmpty(t, embedded)
-
-	canonical, err := os.ReadFile(filepath.Join("public_key.asc"))
-	require.NoError(t, err)
-
-	require.Equal(t, canonical, embedded, "embedded public_key.asc must match install/public_key.asc (symlink target)")
-}
 
 func TestGetSigAssetName(t *testing.T) {
 	require.Equal(t, "cre_linux_amd64.sig", getSigAssetName("linux", "amd64"))
-	require.Equal(t, "cre_darwin_arm64.sig", getSigAssetName("darwin", "arm64"))
 }
 
 func TestGetAssetName(t *testing.T) {

--- a/cmd/update/verify_test.go
+++ b/cmd/update/verify_test.go
@@ -1,10 +1,23 @@
 package update
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/smartcontractkit/cre-cli/install"
 	"github.com/stretchr/testify/require"
 )
+
+func TestReleasePublicKeyMatchesInstall(t *testing.T) {
+	embedded := install.ReleasePublicKey
+	require.NotEmpty(t, embedded)
+
+	canonical, err := os.ReadFile(filepath.Join("public_key.asc"))
+	require.NoError(t, err)
+
+	require.Equal(t, canonical, embedded, "embedded public_key.asc must match install/public_key.asc (symlink target)")
+}
 
 func TestGetSigAssetName(t *testing.T) {
 	require.Equal(t, "cre_linux_amd64.sig", getSigAssetName("linux", "amd64"))

--- a/cmd/update/verify_windows.go
+++ b/cmd/update/verify_windows.go
@@ -9,6 +9,9 @@ import (
 	"strings"
 )
 
+// windowsSignerSubject is a substring of the Authenticode certificate subject.
+const windowsSignerSubject = "Smart Contract"
+
 func verifyReleaseBinary(binPath, _ string) error {
 	escaped := strings.ReplaceAll(binPath, "'", "''")
 	script := fmt.Sprintf(

--- a/cmd/update/verify_windows.go
+++ b/cmd/update/verify_windows.go
@@ -10,7 +10,7 @@ import (
 )
 
 // windowsSignerSubject is a substring of the Authenticode certificate subject.
-const windowsSignerSubject = "Smart Contract"
+const windowsSignerSubject = "SmartContract"
 
 func verifyReleaseBinary(binPath, _ string) error {
 	escaped := strings.ReplaceAll(binPath, "'", "''")

--- a/cmd/update/verify_windows.go
+++ b/cmd/update/verify_windows.go
@@ -1,0 +1,30 @@
+//go:build windows
+
+package update
+
+import (
+	"bytes"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+func verifyReleaseBinary(binPath, _ string) error {
+	escaped := strings.ReplaceAll(binPath, "'", "''")
+	script := fmt.Sprintf(
+		`$ErrorActionPreference = 'Stop'; $s = Get-AuthenticodeSignature -FilePath '%s'; if ($s.Status -ne 'Valid') { Write-Error ('authenticode status: ' + $s.Status); exit 1 }; if (-not $s.SignerCertificate) { Write-Error 'missing signer certificate'; exit 1 }; if ($s.SignerCertificate.Subject -notlike '*%s*') { Write-Error ('unexpected signer: ' + $s.SignerCertificate.Subject); exit 2 }`,
+		escaped,
+		windowsSignerSubject,
+	)
+	cmd := exec.Command("powershell", "-NoProfile", "-NonInteractive", "-Command", script) // #nosec G204 -- script uses escaped path only
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		msg := strings.TrimSpace(stderr.String())
+		if msg != "" {
+			return fmt.Errorf("authenticode verification failed: %s: %w", msg, err)
+		}
+		return fmt.Errorf("authenticode verification failed: %w", err)
+	}
+	return nil
+}

--- a/docs/cre_update.md
+++ b/docs/cre_update.md
@@ -1,6 +1,6 @@
 ## cre update
 
-Update the cre CLI to the latest version
+Update the cre CLI to the latest version. Release signatures are verified before the binary is installed (GPG on Linux, codesign on macOS, Authenticode on Windows).
 
 ```
 cre update [optional flags]

--- a/docs/cre_update.md
+++ b/docs/cre_update.md
@@ -1,6 +1,6 @@
 ## cre update
 
-Update the cre CLI to the latest version. Release signatures are verified before the binary is installed (GPG on Linux, codesign on macOS, Authenticode on Windows).
+Update the cre CLI to the latest version
 
 ```
 cre update [optional flags]

--- a/docs/cre_update.md
+++ b/docs/cre_update.md
@@ -2,6 +2,16 @@
 
 Update the cre CLI to the latest version
 
+### Synopsis
+
+Update the cre CLI to the latest version
+
+Release signatures are verified using the public key published by the CRE team.
+
+On Linux, the signature is verified using GPG.
+On macOS, the signature is verified using codesign.
+On Windows, the signature is verified using Authenticode.
+
 ```
 cre update [optional flags]
 ```

--- a/go.mod
+++ b/go.mod
@@ -49,6 +49,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/test-go/testify v1.1.4
 	go.uber.org/zap v1.28.0
+	golang.org/x/crypto v0.52.0
 	golang.org/x/mod v0.36.0
 	golang.org/x/term v0.43.0
 	golang.org/x/time v0.15.0
@@ -404,7 +405,6 @@ require (
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	go.yaml.in/yaml/v4 v4.0.0-rc.4 // indirect
 	golang.org/x/arch v0.22.0 // indirect
-	golang.org/x/crypto v0.52.0 // indirect
 	golang.org/x/exp v0.0.0-20260508232706-74f9aab9d74a // indirect
 	golang.org/x/net v0.55.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect

--- a/install/keys.go
+++ b/install/keys.go
@@ -1,0 +1,8 @@
+package install
+
+import _ "embed"
+
+// ReleasePublicKey is the Linux GPG public key used to verify cre release binaries.
+//
+//go:embed public_key.asc
+var ReleasePublicKey []byte


### PR DESCRIPTION
[DEVSVCS-5278](https://smartcontract-it.atlassian.net/browse/DEVSVCS-5278)

## Summary

Hardens `cre update` by verifying release authenticity **before** replacing the running binary. Previously, the command downloaded a GitHub release archive, extracted it, and self-replaced with no signature check.

Verification is **mandatory and fail-closed**: any failure aborts before `chmod` / `replaceSelf`. There is no skip flag.

### Platform verification

| Platform | Mechanism | Trust anchor |
|----------|-----------|--------------|
| **Linux** | GPG detached signature on extracted binary | Embedded `install/public_key.asc` via new [`install/keys.go`](install/keys.go); `.sig` downloaded from release |
| **macOS** | `codesign --verify --strict --identifier com.smartcontract.cre.cli` | OS codesign trust |
| **Windows** | PowerShell `Get-AuthenticodeSignature` (Valid + `SmartContract` in subject) | OS Authenticode trust |

### Update flow

```
fetch tag → download archive → extract binary → verify signature → chmod → replaceSelf
```

On Linux, the matching `.sig` asset (e.g. `cre_linux_amd64.sig`) is downloaded after extraction.

### Other changes

- Refactored `getAssetName()` to return `archName` for sig asset naming
- Added platform-specific `verify_*.go` files with build tags
- Unit tests for GPG verification (Linux), `Run()` integration via httpmock, and helper tests
- Updated `cre update` command long help and [`docs/cre_update.md`](docs/cre_update.md)