### PR TITLE
Fix Telemetry Flag Capture and Workflow Language Attribution

### DIFF
--- a/cmd/workflow/convert/convert.go
+++ b/cmd/workflow/convert/convert.go
@@ -108,6 +108,9 @@ func (h *handler) Execute(inputs Inputs) error {
 		return fmt.Errorf("cannot detect workflow language: %w", err)
 	}
 	lang := cmdcommon.GetWorkflowLanguage(workflowPath)
+	if h.runtimeContext != nil {
+		h.runtimeContext.Workflow.Language = lang
+	}
 	if lang == constants.WorkflowLanguageWasm {
 		return fmt.Errorf("workflow is already a custom build (workflow-path is %s)", currentPath)
 	}

--- a/cmd/workflow/deploy/compile.go
+++ b/cmd/workflow/deploy/compile.go
@@ -17,6 +17,9 @@ func (h *handler) Compile(ctx context.Context) error {
 
 	// URL wasm is handled directly in Execute(); nothing to compile or write locally.
 	if cmdcommon.IsURL(h.inputs.WasmPath) {
+		if h.runtimeContext != nil {
+			h.runtimeContext.Workflow.Language = constants.WorkflowLanguageWasm
+		}
 		return nil
 	}
 
@@ -29,13 +32,13 @@ func (h *handler) Compile(ctx context.Context) error {
 	var err error
 
 	if h.inputs.WasmPath != "" {
+		if h.runtimeContext != nil {
+			h.runtimeContext.Workflow.Language = constants.WorkflowLanguageWasm
+		}
 		ui.Dim("Reading pre-built WASM binary...")
 		wasmFile, err = os.ReadFile(h.inputs.WasmPath)
 		if err != nil {
 			return fmt.Errorf("failed to read WASM binary from %s: %w", h.inputs.WasmPath, err)
-		}
-		if h.runtimeContext != nil {
-			h.runtimeContext.Workflow.Language = constants.WorkflowLanguageWasm
 		}
 		h.log.Debug().Str("path", h.inputs.WasmPath).Msg("Loaded pre-built WASM binary")
 

--- a/cmd/workflow/simulate/simulate.go
+++ b/cmd/workflow/simulate/simulate.go
@@ -277,6 +277,9 @@ func (h *handler) Execute(ctx context.Context, inputs Inputs) error {
 	var err error
 
 	if inputs.WasmPath != "" {
+		if h.runtimeContext != nil {
+			h.runtimeContext.Workflow.Language = constants.WorkflowLanguageWasm
+		}
 		if cmdcommon.IsURL(inputs.WasmPath) {
 			ui.Dim("Fetching WASM binary from URL...")
 			wasmFileBinary, err = cmdcommon.FetchURL(ctx, inputs.WasmPath)
@@ -295,9 +298,6 @@ func (h *handler) Execute(ctx context.Context, inputs Inputs) error {
 		wasmFileBinary, err = cmdcommon.EnsureRawWasm(wasmFileBinary)
 		if err != nil {
 			return fmt.Errorf("failed to decode WASM binary: %w", err)
-		}
-		if h.runtimeContext != nil {
-			h.runtimeContext.Workflow.Language = constants.WorkflowLanguageWasm
 		}
 	} else {
 		workflowDir, err := os.Getwd()

--- a/internal/redact/redact.go
+++ b/internal/redact/redact.go
@@ -8,6 +8,12 @@ import (
 
 const RedactedValue = "[REDACTED]"
 
+// maxFlagValueLength bounds the length of a flag value that is otherwise considered
+// safe to record. A well-formed CLI flag value (identifier, path, enum, number) is
+// always well under this; anything longer is more likely to be output, an error
+// message, or a payload that ended up in a flag's Value by accident.
+const maxFlagValueLength = 256
+
 var (
 	fullRedactFlags = map[string]struct{}{
 		"env":                    {},
@@ -16,6 +22,13 @@ var (
 		"public_key":             {},
 		"ledger-derivation-path": {},
 		"config":                 {},
+		"changeset-file":         {},
+	}
+
+	// pathRedactFlags hold filesystem paths. Only the base name is kept, since the
+	// full path can leak local directory structure or the OS username.
+	pathRedactFlags = map[string]struct{}{
+		"project-root": {},
 	}
 
 	urlValueFlags = map[string]struct{}{
@@ -31,6 +44,11 @@ var (
 	urlPattern        = regexp.MustCompile(`https?://[^\s"'<>]+`)
 
 	templateAddSensitivePattern = regexp.MustCompile(`(?i)(://|\?|ghp_[A-Za-z0-9]+|github_pat_[A-Za-z0-9_]+)`)
+
+	// suspiciousContentPattern matches text that looks like it came from command
+	// output, an error/stack trace, or an HTTP exchange rather than a value a user
+	// would type as a CLI flag.
+	suspiciousContentPattern = regexp.MustCompile(`(?i)(traceback|panic:|goroutine \d|exception|stack trace|"error"\s*:|http/1\.[01]\s+\d{3}|<html)`)
 )
 
 // Flag redacts a single CLI flag value based on flag name.
@@ -51,7 +69,32 @@ func Flag(name, value string) string {
 		return redactURLFlagValue(name, value)
 	}
 
+	if _, ok := pathRedactFlags[name]; ok {
+		return filepath.Base(value)
+	}
+
+	if looksLikeUnintendedContent(value) {
+		return RedactedValue
+	}
+
 	return value
+}
+
+// looksLikeUnintendedContent flags values that don't look like something a user
+// would type as a CLI flag - e.g. command output, an error message, or an escaped
+// HTTP payload that ended up bound to a flag's Value instead of its intended input.
+func looksLikeUnintendedContent(value string) bool {
+	if len(value) > maxFlagValueLength {
+		return true
+	}
+	if strings.ContainsAny(value, "\n\r") {
+		return true
+	}
+	trimmed := strings.TrimSpace(value)
+	if strings.HasPrefix(trimmed, "{") || strings.HasPrefix(trimmed, "[") {
+		return true
+	}
+	return suspiciousContentPattern.MatchString(value)
 }
 
 func isNonSensitiveLimitsValue(value string) bool {
@@ -106,6 +149,14 @@ func Args(action, subcommand string, args []string) []string {
 					redacted[i] = RedactedValue
 				}
 			}
+		}
+	}
+
+	// Backstop: positional args are otherwise passed through verbatim, so guard
+	// against output/error/payload text that ended up on the command line.
+	for i, arg := range redacted {
+		if arg != RedactedValue && looksLikeUnintendedContent(arg) {
+			redacted[i] = RedactedValue
 		}
 	}
 

--- a/internal/redact/redact_test.go
+++ b/internal/redact/redact_test.go
@@ -1,6 +1,7 @@
 package redact
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -76,6 +77,13 @@ func TestFlag(t *testing.T) {
 		{name: "wasm remote url", flagName: "wasm", value: "https://cdn.example.com/wasm/secret", want: "https://cdn.example.com/wasm/***"},
 		{name: "benign flag", flagName: "verbose", value: "true", want: "true"},
 		{name: "empty value", flagName: "env", value: "", want: ""},
+		{name: "changeset file path", flagName: "changeset-file", value: "./changeset.yaml", want: RedactedValue},
+		{name: "project root basename", flagName: "project-root", value: "/home/user/my-project", want: "my-project"},
+		{name: "unintended json blob on arbitrary flag", flagName: "owner-label", value: `{"key":"value"}`, want: RedactedValue},
+		{name: "unintended multiline output on arbitrary flag", flagName: "run", value: "line one\nline two", want: RedactedValue},
+		{name: "unintended stack trace on arbitrary flag", flagName: "run", value: "panic: runtime error", want: RedactedValue},
+		{name: "unintended oversized value on arbitrary flag", flagName: "run", value: strings.Repeat("a", maxFlagValueLength+1), want: RedactedValue},
+		{name: "benign free-form value passes through", flagName: "owner-label", value: "my-team", want: "my-team"},
 	}
 
 	for _, tt := range tests {
@@ -120,6 +128,20 @@ func TestArgs(t *testing.T) {
 			subcommand: "get",
 			args:       []string{"my-workflow"},
 			want:       []string{"my-workflow"},
+		},
+		{
+			name:       "unintended json blob arg redacted",
+			action:     "workflow",
+			subcommand: "get",
+			args:       []string{`{"unexpected":"payload"}`},
+			want:       []string{RedactedValue},
+		},
+		{
+			name:       "unintended multiline arg redacted",
+			action:     "workflow",
+			subcommand: "get",
+			args:       []string{"line one\nline two"},
+			want:       []string{RedactedValue},
 		},
 	}
 


### PR DESCRIPTION
### Problem
Telemetry was capturing command output, error messages, and HTTP payloads as flag values, and workflow_language was missing from some command events (especially failures).

### Solution

#### Flag Sanitization (core fix)

- Added garbage detection: New looksLikeUnintendedContent() redacts any flag value that doesn't look like a real CLI argument — catches >256 char values, newlines, JSON blobs ({/[), and output signatures (panic:, traceback, goroutine, HTTP/1.x, "error", <html).
- Closed flag-name gaps: Added changeset-file to full-redact list, project-root to path-redact (basename only).
- Backstop on args: Same guard applied to positional arguments for defense-in-depth.

#### Workflow Language Attachment

- convert command: Now captures detected workflow language (was computing it but discarding).
- deploy & simulate: Moved WASM language assignment earlier — now fires as soon as WASM path is known, before read/fetch/compile operations that can fail. Ensures language is recorded even on failure.