### PR TITLE
Isolate test env process to prevent user context overwrite

### DIFF
--- a/internal/testutil/cli_home.go
+++ b/internal/testutil/cli_home.go
@@ -1,0 +1,76 @@
+package testutil
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// IsolateCLIHome redirects CLI config writes (~/.cre) into a temp directory.
+// Call in tests that run the cre binary or invoke EnsureContext/FetchAndWriteContext.
+func IsolateCLIHome(t *testing.T) string {
+	t.Helper()
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	PinGoCacheForTestHome(t)
+	return home
+}
+
+// PinGoCacheForTestHome keeps GOPATH/GOMODCACHE outside temp HOME directories.
+// Overriding HOME makes Go default GOPATH to $HOME/go; module files are read-only and break TempDir cleanup.
+func PinGoCacheForTestHome(t *testing.T) {
+	t.Helper()
+
+	gopath, gomodcache := realGoCacheEnv(t)
+	t.Setenv("GOPATH", gopath)
+	t.Setenv("GOMODCACHE", gomodcache)
+}
+
+func realGoCacheEnv(t *testing.T) (gopath, gomodcache string) {
+	t.Helper()
+
+	realHome, err := os.UserHomeDir()
+	require.NoError(t, err, "failed to get real home dir")
+
+	gopath = os.Getenv("GOPATH")
+	if gopath == "" {
+		gopath = filepath.Join(realHome, "go")
+	}
+
+	gomodcache = os.Getenv("GOMODCACHE")
+	if gomodcache == "" {
+		gomodcache = filepath.Join(gopath, "pkg", "mod")
+	}
+
+	return gopath, gomodcache
+}
+
+// CLIChildEnv builds subprocess env with isolated HOME for credentials and pinned Go cache paths.
+func CLIChildEnv(t *testing.T, testHome string) []string {
+	t.Helper()
+
+	gopath, gomodcache := realGoCacheEnv(t)
+
+	childEnv := make([]string, 0, len(os.Environ())+4)
+	for _, entry := range os.Environ() {
+		if strings.HasPrefix(entry, "HOME=") ||
+			strings.HasPrefix(entry, "USERPROFILE=") ||
+			strings.HasPrefix(entry, "GOPATH=") ||
+			strings.HasPrefix(entry, "GOMODCACHE=") {
+			continue
+		}
+		childEnv = append(childEnv, entry)
+	}
+	childEnv = append(childEnv,
+		"HOME="+testHome,
+		"USERPROFILE="+testHome,
+		"GOPATH="+gopath,
+		"GOMODCACHE="+gomodcache,
+	)
+	return childEnv
+}

--- a/internal/testutil/cli_home.go
+++ b/internal/testutil/cli_home.go
@@ -5,19 +5,36 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-
-	"github.com/stretchr/testify/require"
 )
+
+var (
+	defaultGoPath     string
+	defaultGoModCache string
+)
+
+func init() {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		home = "/tmp"
+	}
+	defaultGoPath = filepath.Join(home, "go")
+	defaultGoModCache = filepath.Join(defaultGoPath, "pkg", "mod")
+}
 
 // IsolateCLIHome redirects CLI config writes (~/.cre) into a temp directory.
 // Call in tests that run the cre binary or invoke EnsureContext/FetchAndWriteContext.
 func IsolateCLIHome(t *testing.T) string {
 	t.Helper()
 
+	// Resolve Go cache paths before overriding HOME. os.UserHomeDir() follows $HOME,
+	// so reading it after t.Setenv("HOME", tempDir) would pin GOPATH inside the temp dir.
+	gopath, gomodcache := resolvedGoCachePaths()
+
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	t.Setenv("USERPROFILE", home)
-	PinGoCacheForTestHome(t)
+	t.Setenv("GOPATH", gopath)
+	t.Setenv("GOMODCACHE", gomodcache)
 	return home
 }
 
@@ -26,20 +43,15 @@ func IsolateCLIHome(t *testing.T) string {
 func PinGoCacheForTestHome(t *testing.T) {
 	t.Helper()
 
-	gopath, gomodcache := realGoCacheEnv(t)
+	gopath, gomodcache := resolvedGoCachePaths()
 	t.Setenv("GOPATH", gopath)
 	t.Setenv("GOMODCACHE", gomodcache)
 }
 
-func realGoCacheEnv(t *testing.T) (gopath, gomodcache string) {
-	t.Helper()
-
-	realHome, err := os.UserHomeDir()
-	require.NoError(t, err, "failed to get real home dir")
-
+func resolvedGoCachePaths() (gopath, gomodcache string) {
 	gopath = os.Getenv("GOPATH")
 	if gopath == "" {
-		gopath = filepath.Join(realHome, "go")
+		gopath = defaultGoPath
 	}
 
 	gomodcache = os.Getenv("GOMODCACHE")
@@ -54,7 +66,7 @@ func realGoCacheEnv(t *testing.T) (gopath, gomodcache string) {
 func CLIChildEnv(t *testing.T, testHome string) []string {
 	t.Helper()
 
-	gopath, gomodcache := realGoCacheEnv(t)
+	gopath, gomodcache := resolvedGoCachePaths()
 
 	childEnv := make([]string, 0, len(os.Environ())+4)
 	for _, entry := range os.Environ() {

--- a/internal/testutil/cli_home.go
+++ b/internal/testutil/cli_home.go
@@ -7,10 +7,7 @@ import (
 	"testing"
 )
 
-var (
-	defaultGoPath     string
-	defaultGoModCache string
-)
+var defaultGoPath string
 
 func init() {
 	home, err := os.UserHomeDir()
@@ -18,7 +15,6 @@ func init() {
 		home = "/tmp"
 	}
 	defaultGoPath = filepath.Join(home, "go")
-	defaultGoModCache = filepath.Join(defaultGoPath, "pkg", "mod")
 }
 
 // IsolateCLIHome redirects CLI config writes (~/.cre) into a temp directory.

--- a/internal/testutil/graphql_mock.go
+++ b/internal/testutil/graphql_mock.go
@@ -76,6 +76,8 @@ func MockGetTenantConfigGraphQLPayloadWithCapReg(capRegAddress string) map[strin
 // It sets EnvVarGraphQLURL so CLI commands use this server. Caller must defer srv.Close().
 func NewGraphQLMockServerGetOrganization(t *testing.T) *httptest.Server {
 	t.Helper()
+	IsolateCLIHome(t)
+
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.HasPrefix(r.URL.Path, "/graphql") && r.Method == http.MethodPost {
 			var req struct {

--- a/test/common.go
+++ b/test/common.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/smartcontractkit/cre-cli/internal/constants"
 	"github.com/smartcontractkit/cre-cli/internal/settings"
+	"github.com/smartcontractkit/cre-cli/internal/testutil"
 )
 
 var (
@@ -71,6 +72,8 @@ type TestConfig struct {
 }
 
 func NewTestConfig(t *testing.T) *TestConfig {
+	testutil.IsolateCLIHome(t)
+
 	uid := "test-" + uuid.New().String()
 	err := os.MkdirAll(fmt.Sprintf("/tmp/%s", uid), 0755)
 	if err != nil {

--- a/test/multi_command_flows/workflow_private_registry.go
+++ b/test/multi_command_flows/workflow_private_registry.go
@@ -76,59 +76,6 @@ func CreateTestBearerCredentialsHome(t *testing.T) string {
 	return homeDir
 }
 
-// realGoCacheEnv returns GOPATH and GOMODCACHE locations outside t.TempDir()-backed HOME dirs.
-// Overriding HOME makes Go default GOPATH to $HOME/go; module files are read-only and break TempDir cleanup.
-func realGoCacheEnv(t *testing.T) (gopath, gomodcache string) {
-	t.Helper()
-
-	realHome, err := os.UserHomeDir()
-	require.NoError(t, err, "failed to get real home dir")
-
-	gopath = os.Getenv("GOPATH")
-	if gopath == "" {
-		gopath = filepath.Join(realHome, "go")
-	}
-
-	gomodcache = os.Getenv("GOMODCACHE")
-	if gomodcache == "" {
-		gomodcache = filepath.Join(gopath, "pkg", "mod")
-	}
-
-	return gopath, gomodcache
-}
-
-// pinGoCacheForTestHome keeps module cache out of temp HOME directories in the test process.
-func pinGoCacheForTestHome(t *testing.T) {
-	t.Helper()
-	gopath, gomodcache := realGoCacheEnv(t)
-	t.Setenv("GOPATH", gopath)
-	t.Setenv("GOMODCACHE", gomodcache)
-}
-
-// cliChildEnv builds subprocess env with isolated HOME for credentials and pinned Go cache paths.
-func cliChildEnv(t *testing.T, testHome string) []string {
-	t.Helper()
-	gopath, gomodcache := realGoCacheEnv(t)
-
-	childEnv := make([]string, 0, len(os.Environ())+4)
-	for _, entry := range os.Environ() {
-		if strings.HasPrefix(entry, "HOME=") ||
-			strings.HasPrefix(entry, "USERPROFILE=") ||
-			strings.HasPrefix(entry, "GOPATH=") ||
-			strings.HasPrefix(entry, "GOMODCACHE=") {
-			continue
-		}
-		childEnv = append(childEnv, entry)
-	}
-	childEnv = append(childEnv,
-		"HOME="+testHome,
-		"USERPROFILE="+testHome,
-		"GOPATH="+gopath,
-		"GOMODCACHE="+gomodcache,
-	)
-	return childEnv
-}
-
 func createTestJWT(orgID string) string {
 	return testjwt.CreateTestJWT(orgID)
 }
@@ -297,7 +244,7 @@ func workflowDeployPrivateRegistry(t *testing.T, tc TestConfig) string {
 
 	cmd := exec.Command(CLIPath, args...)
 	testHome := CreateTestBearerCredentialsHome(t)
-	cmd.Env = cliChildEnv(t, testHome)
+	cmd.Env = testutil.CLIChildEnv(t, testHome)
 
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout, cmd.Stderr = &stdout, &stderr
@@ -456,7 +403,7 @@ func workflowPausePrivateRegistry(t *testing.T, tc TestConfig) string {
 
 	cmd := exec.Command(CLIPath, args...)
 	testHome := CreateTestBearerCredentialsHome(t)
-	cmd.Env = cliChildEnv(t, testHome)
+	cmd.Env = testutil.CLIChildEnv(t, testHome)
 
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout, cmd.Stderr = &stdout, &stderr
@@ -611,7 +558,7 @@ func workflowActivatePrivateRegistry(t *testing.T, tc TestConfig) string {
 
 	cmd := exec.Command(CLIPath, args...)
 	testHome := CreateTestBearerCredentialsHome(t)
-	cmd.Env = cliChildEnv(t, testHome)
+	cmd.Env = testutil.CLIChildEnv(t, testHome)
 
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout, cmd.Stderr = &stdout, &stderr
@@ -754,7 +701,7 @@ func workflowDeletePrivateRegistry(t *testing.T, tc TestConfig) string {
 
 	cmd := exec.Command(CLIPath, args...)
 	testHome := CreateTestBearerCredentialsHome(t)
-	cmd.Env = cliChildEnv(t, testHome)
+	cmd.Env = testutil.CLIChildEnv(t, testHome)
 
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout, cmd.Stderr = &stdout, &stderr
@@ -846,7 +793,7 @@ func RunPrivateRegistryAuthAndSettingsFinalize(t *testing.T, envPath, blankWorkf
 	bearerHome := CreateTestBearerCredentialsHome(t)
 	t.Setenv("HOME", bearerHome)
 	t.Setenv("USERPROFILE", bearerHome)
-	pinGoCacheForTestHome(t)
+	testutil.PinGoCacheForTestHome(t)
 
 	logger := testutil.NewTestLogger()
 	creds, err := credentials.New(logger)


### PR DESCRIPTION
Redirect CLI config writes to a temp directory via testutil.IsolateCLIHome() in NewTestConfig, NewGraphQLMockServerGetOrganization, and private-registry subprocess tests.