### PR TITLE
Add Homebrew tap support

### DIFF
--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -1,0 +1,71 @@
+name: Homebrew
+
+on:
+  release:
+    types: [published]
+  pull_request:
+    paths:
+      - Formula/**
+      - .github/workflows/homebrew.yml
+
+jobs:
+  update-formula:
+    name: Update Homebrew Formula
+    if: github.event_name == 'release'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # actions/checkout@v4.2.2
+        with:
+          ref: main
+
+      - name: Update Formula
+        run: ./scripts/update-homebrew-formula.sh "${{ github.event.release.tag_name }}"
+
+      - name: Commit and Push Formula Update
+        run: |
+          if git diff --quiet -- Formula/cre.rb; then
+            echo "Formula already up to date."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add Formula/cre.rb
+          git commit -m "chore(homebrew): update cre formula to ${{ github.event.release.tag_name }}"
+          git push
+
+  validate-formula:
+    name: Validate Homebrew Formula (${{ matrix.os }})
+    if: github.event_name == 'pull_request'
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macOS
+            runner: macos-latest
+          - os: Linux
+            runner: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # actions/checkout@v4.2.2
+
+      - name: Set up Homebrew
+        if: matrix.os == 'Linux'
+        run: echo "/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin" >> "$GITHUB_PATH"
+
+      - name: Install Formula
+        env:
+          HOMEBREW_NO_REQUIRE_TAP_TRUST: 1
+        run: |
+          brew tap smartcontractkit/cre-cli "${{ github.workspace }}"
+          brew install smartcontractkit/cre-cli/cre
+
+      - name: Test Formula
+        run: brew test cre
+
+      - name: Audit Formula
+        run: brew audit --strict cre

--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -41,6 +41,8 @@ jobs:
     name: Validate Homebrew Formula (${{ matrix.os }})
     if: github.event_name == 'pull_request'
     runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:

--- a/Formula/cre.rb
+++ b/Formula/cre.rb
@@ -1,0 +1,45 @@
+class Cre < Formula
+  desc "Chainlink Runtime Environment CLI"
+  homepage "https://chain.link/chainlink-runtime-environment"
+  version "1.24.0"
+  license "MIT"
+
+  on_macos do
+    on_arm do
+      url "https://github.com/smartcontractkit/cre-cli/releases/download/v1.24.0/cre_darwin_arm64.zip"
+      sha256 "f4fb8837a6100f9c60cdf78af8fa7f3add681b2fa1938d47cd2786f195ee8756"
+    end
+    on_intel do
+      url "https://github.com/smartcontractkit/cre-cli/releases/download/v1.24.0/cre_darwin_amd64.zip"
+      sha256 "98f88553f98830cf275cfa935f83b080839a833691ebe6946f8e7592e88b5c38"
+    end
+  end
+
+  on_linux do
+    on_arm do
+      url "https://github.com/smartcontractkit/cre-cli/releases/download/v1.24.0/cre_linux_arm64.tar.gz"
+      sha256 "302cf8356618c7f02191a2ed1c04544d31dea5014f1f16736e7ca66dd9fb17ff"
+    end
+    on_intel do
+      url "https://github.com/smartcontractkit/cre-cli/releases/download/v1.24.0/cre_linux_amd64.tar.gz"
+      sha256 "68e93dcda31ee02cee956575f5455e90748e5dba2971ee7868e33e82f8be6027"
+    end
+  end
+
+  def install
+    arch = Hardware::CPU.arm? ? "arm64" : "amd64"
+    platform = OS.mac? ? "darwin" : "linux"
+    bin.install Dir["cre_v*_#{platform}_#{arch}"].first => "cre"
+  end
+
+  def caveats
+    <<~EOS
+      Go 1.25.3 or later and Bun 1.0.0 or later are recommended for developing
+      and running TypeScript CRE workflows.
+    EOS
+  end
+
+  test do
+    assert_match "CRE CLI version v#{version}", shell_output("#{bin}/cre version")
+  end
+end

--- a/README.md
+++ b/README.md
@@ -16,11 +16,38 @@
 A Go/Cobra-based command-line tool for building, testing, and managing Chainlink Runtime Environment (CRE) workflows. This repository contains the CLI source code and developer tooling.
 
 - [Installation](#installation)
+- [End-user Installation](#end-user-installation)
 - [Developer Commands](#developer-commands)
 - [CRE Commands](#commands)
 - [Legal Notice](#legal-notice)
 
 ## Installation
+
+### End-user Installation
+
+Install the latest release with Homebrew:
+
+```bash
+brew tap smartcontractkit/cre-cli https://github.com/smartcontractkit/cre-cli
+brew install cre
+cre version
+```
+
+Or use the universal installer:
+
+```bash
+curl -sSL https://app.chain.link/install.sh | bash
+```
+
+To upgrade a Homebrew install:
+
+```bash
+brew upgrade cre
+```
+
+For a future `homebrew-core` submission, see [docs/homebrew-core-prerequisites.md](docs/homebrew-core-prerequisites.md).
+
+### Developer Installation
 
 1. Clone the repository:
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ To upgrade a Homebrew install:
 brew upgrade cre
 ```
 
-For a future `homebrew-core` submission, see [docs/homebrew-core-prerequisites.md](docs/homebrew-core-prerequisites.md).
+For a future `homebrew-core` submission, see [homebrew-core-prerequisites.md](homebrew-core-prerequisites.md).
 
 ### Developer Installation
 

--- a/docs/homebrew-core-prerequisites.md
+++ b/docs/homebrew-core-prerequisites.md
@@ -1,0 +1,56 @@
+# Homebrew Core Prerequisites
+
+This document tracks blockers for submitting `cre` to [homebrew-core](https://github.com/Homebrew/homebrew-core) so users can run `brew install cre` without a tap.
+
+The in-repo formula at [Formula/cre.rb](../Formula/cre.rb) is the supported distribution path until these prerequisites are met.
+
+## Current blockers
+
+| Blocker | Status | Notes |
+|---|---|---|
+| Notability | Blocked | Homebrew requires ~225 GitHub stars for self-submitted software. cre-cli currently has low adoption relative to that threshold. |
+| Source build | Blocked | Production builds use `CGO_ENABLED=1` and a GitHub token for `smartcontractkit/*` modules. Homebrew CI cannot use private credentials. |
+| Go version alignment | Blocked | `go.mod` specifies Go 1.26.4 while CI/release workflows use Go 1.25.x. Versions should be aligned before submission. |
+| Stable test output | Ready | `cre version` prints `CRE CLI version vX.Y.Z`, suitable for a `test do` block. |
+
+## Required before opening a homebrew-core PR
+
+1. Grow project notability (stars, forks, documented adoption).
+2. Ensure `go build` succeeds on a clean machine without `GITHUB_TOKEN` (all modules publicly resolvable).
+3. Document and satisfy any CGO/system library requirements for source builds.
+4. Align Go versions across `go.mod`, CI, and release workflows.
+5. Fork `homebrew/homebrew-core`, add `Formula/c/cre.rb` as a **source-build** formula, and pass:
+   - `brew audit --new-formula --strict cre`
+   - `brew install --build-from-source cre`
+   - `brew test cre`
+
+## Source-build formula sketch
+
+When the blockers above are resolved, use a source-build formula similar to:
+
+```ruby
+class Cre < Formula
+  desc "Chainlink Runtime Environment CLI"
+  homepage "https://chain.link/chainlink-runtime-environment"
+  url "https://github.com/smartcontractkit/cre-cli/archive/refs/tags/vX.Y.Z.tar.gz"
+  sha256 "..."
+  license "MIT"
+
+  depends_on "go" => :build
+
+  def install
+    ldflags = "-s -w -X github.com/smartcontractkit/cre-cli/cmd/version.Version=version v#{version}"
+    system "go", "build", *std_go_args(ldflags:), "."
+  end
+
+  test do
+    assert_match "CRE CLI version v#{version}", shell_output("#{bin}/cre version")
+  end
+end
+```
+
+## Submission checklist
+
+1. Confirm all blockers above are resolved.
+2. Open a PR titled `cre X.Y.Z (new formula)` against `homebrew/homebrew-core`.
+3. Respond to maintainer review feedback until CI passes.

--- a/homebrew-core-prerequisites.md
+++ b/homebrew-core-prerequisites.md
@@ -2,7 +2,7 @@
 
 This document tracks blockers for submitting `cre` to [homebrew-core](https://github.com/Homebrew/homebrew-core) so users can run `brew install cre` without a tap.
 
-The in-repo formula at [Formula/cre.rb](../Formula/cre.rb) is the supported distribution path until these prerequisites are met.
+The in-repo formula at [Formula/cre.rb](Formula/cre.rb) is the supported distribution path until these prerequisites are met.
 
 ## Current blockers
 

--- a/install/install.sh
+++ b/install/install.sh
@@ -302,6 +302,13 @@ case "$ARCH" in
     ;;
 esac
 
+if command -v brew >/dev/null 2>&1; then
+  echo "Homebrew detected. You can install cre with:"
+  echo "  brew tap smartcontractkit/cre-cli https://github.com/smartcontractkit/cre-cli"
+  echo "  brew install cre"
+  echo
+fi
+
 if [[ ! -d $bin_dir ]]; then
     mkdir -p "$bin_dir" ||
         fail "Failed to create install directory \"$bin_dir\""

--- a/scripts/update-homebrew-formula.sh
+++ b/scripts/update-homebrew-formula.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+#
+# Update Formula/cre.rb with version and checksums from a published GitHub release.
+#
+# Usage:
+#   ./scripts/update-homebrew-formula.sh v1.24.0
+#   ./scripts/update-homebrew-formula.sh   # uses latest published release
+
+set -euo pipefail
+
+REPO="smartcontractkit/cre-cli"
+FORMULA_FILE="Formula/cre.rb"
+GITHUB_API="https://api.github.com/repos/${REPO}"
+
+fail() {
+  echo "Error: $1" >&2
+  exit 1
+}
+
+TAG="${1:-}"
+if [[ -z "${TAG}" ]]; then
+  TAG="$(curl -fsSL "${GITHUB_API}/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')"
+fi
+
+[[ "${TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || fail "Invalid tag format: ${TAG} (expected vX.Y.Z)"
+
+VERSION="${TAG#v}"
+CHECKSUMS_URL="https://github.com/${REPO}/releases/download/${TAG}/checksums.txt"
+CHECKSUMS="$(curl -fsSL "${CHECKSUMS_URL}")"
+
+lookup_checksum() {
+  local versioned_name="$1"
+  local checksum
+  checksum="$(printf '%s\n' "${CHECKSUMS}" | grep "^${versioned_name}:" | head -1 | awk '{print $2}')"
+  [[ -n "${checksum}" ]] || fail "Checksum not found for ${versioned_name}"
+  printf '%s' "${checksum}"
+}
+
+DARWIN_ARM64_SHA="$(lookup_checksum "cre_v${VERSION}_darwin_arm64.zip")"
+DARWIN_AMD64_SHA="$(lookup_checksum "cre_v${VERSION}_darwin_amd64.zip")"
+LINUX_ARM64_SHA="$(lookup_checksum "cre_v${VERSION}_linux_arm64.tar.gz")"
+LINUX_AMD64_SHA="$(lookup_checksum "cre_v${VERSION}_linux_amd64.tar.gz")"
+
+cat > "${FORMULA_FILE}" <<EOF
+class Cre < Formula
+  desc "Chainlink Runtime Environment CLI"
+  homepage "https://chain.link/chainlink-runtime-environment"
+  version "${VERSION}"
+  license "MIT"
+
+  on_macos do
+    on_arm do
+      url "https://github.com/smartcontractkit/cre-cli/releases/download/${TAG}/cre_darwin_arm64.zip"
+      sha256 "${DARWIN_ARM64_SHA}"
+    end
+    on_intel do
+      url "https://github.com/smartcontractkit/cre-cli/releases/download/${TAG}/cre_darwin_amd64.zip"
+      sha256 "${DARWIN_AMD64_SHA}"
+    end
+  end
+
+  on_linux do
+    on_arm do
+      url "https://github.com/smartcontractkit/cre-cli/releases/download/${TAG}/cre_linux_arm64.tar.gz"
+      sha256 "${LINUX_ARM64_SHA}"
+    end
+    on_intel do
+      url "https://github.com/smartcontractkit/cre-cli/releases/download/${TAG}/cre_linux_amd64.tar.gz"
+      sha256 "${LINUX_AMD64_SHA}"
+    end
+  end
+
+  def install
+    arch = Hardware::CPU.arm? ? "arm64" : "amd64"
+    platform = OS.mac? ? "darwin" : "linux"
+    bin.install Dir["cre_v*_#{platform}_#{arch}"].first => "cre"
+  end
+
+  def caveats
+    <<~EOS
+      Go 1.25.3 or later and Bun 1.0.0 or later are recommended for developing
+      and running TypeScript CRE workflows.
+    EOS
+  end
+
+  test do
+    assert_match "CRE CLI version v#{version}", shell_output("#{bin}/cre version")
+  end
+end
+EOF
+
+echo "Updated ${FORMULA_FILE} for ${TAG}"


### PR DESCRIPTION
## Summary

Adds Homebrew distribution for `cre` via an in-repo formula in the public `cre-cli` repo.

- Adds `Formula/cre.rb` (binary formula for v1.24.0, macOS + Linux)
- Adds `scripts/update-homebrew-formula.sh` to regenerate the formula from release checksums
- Adds `.github/workflows/homebrew.yml` to auto-bump the formula on publish and validate on PRs
- Documents install in README and `install/install.sh`
- Adds `docs/homebrew-core-prerequisites.md` for a future `homebrew-core` submission

## Install

```bash
brew tap smartcontractkit/cre-cli https://github.com/smartcontractkit/cre-cli
brew install cre
```

## Test plan

- [ ] `brew tap smartcontractkit/cre-cli https://github.com/smartcontractkit/cre-cli && brew install cre`
- [ ] `brew test cre` and `brew audit --strict cre`
- [ ] Confirm Homebrew CI passes on PR
- [ ] Confirm formula auto-updates after the next published release