### PR TITLE
Warn on production deploy with EOA ownership

### DIFF
--- a/cmd/workflow/deploy/deploy.go
+++ b/cmd/workflow/deploy/deploy.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/rs/zerolog"
 	"github.com/spf13/cobra"
@@ -14,6 +15,7 @@ import (
 	cmdcommon "github.com/smartcontractkit/cre-cli/cmd/common"
 	workflowcommon "github.com/smartcontractkit/cre-cli/cmd/workflow/common"
 	"github.com/smartcontractkit/cre-cli/internal/accessrequest"
+	"github.com/smartcontractkit/cre-cli/internal/constants"
 	"github.com/smartcontractkit/cre-cli/internal/credentials"
 	"github.com/smartcontractkit/cre-cli/internal/environments"
 	"github.com/smartcontractkit/cre-cli/internal/runtime"
@@ -218,6 +220,8 @@ func (h *handler) Execute(ctx context.Context) error {
 		return h.accessRequester.PromptAndSubmitRequest(ctx)
 	}
 
+	h.warnIfProductionWorkflowWithoutMultisig()
+
 	adapter, err := newRegistryDeployStrategy(ctx, h.runtimeContext.ResolvedRegistry, h)
 	if err != nil {
 		return err
@@ -372,4 +376,19 @@ func warnIfPausedWorkflowUpdate(status *uint8) {
 	if status != nil && *status == workflowStatusPaused {
 		ui.Warning("Your workflow is paused and has been updated")
 	}
+}
+
+func (h *handler) warnIfProductionWorkflowWithoutMultisig() {
+	if !isProductionTarget(h.settings.User.TargetName) {
+		return
+	}
+	if h.settings.Workflow.UserWorkflowSettings.WorkflowOwnerType != constants.WorkflowOwnerTypeEOA {
+		return
+	}
+	ui.Warning("Production workflow deploy is using private-key ownership. Use multi-sig ownership with --unsigned or --changeset for production deployments.")
+}
+
+func isProductionTarget(target string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(target))
+	return strings.Contains(normalized, "production")
 }

--- a/cmd/workflow/deploy/deploy.go
+++ b/cmd/workflow/deploy/deploy.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"strings"
 
 	"github.com/rs/zerolog"
 	"github.com/spf13/cobra"
@@ -220,7 +219,7 @@ func (h *handler) Execute(ctx context.Context) error {
 		return h.accessRequester.PromptAndSubmitRequest(ctx)
 	}
 
-	h.warnIfProductionWorkflowWithoutMultisig()
+	h.warnIfDeployingWithPrivateKey()
 
 	adapter, err := newRegistryDeployStrategy(ctx, h.runtimeContext.ResolvedRegistry, h)
 	if err != nil {
@@ -378,17 +377,9 @@ func warnIfPausedWorkflowUpdate(status *uint8) {
 	}
 }
 
-func (h *handler) warnIfProductionWorkflowWithoutMultisig() {
-	if !isProductionTarget(h.settings.User.TargetName) {
-		return
-	}
+func (h *handler) warnIfDeployingWithPrivateKey() {
 	if h.settings.Workflow.UserWorkflowSettings.WorkflowOwnerType != constants.WorkflowOwnerTypeEOA {
 		return
 	}
-	ui.Warning("Production workflow deploy is using private-key ownership. Use multi-sig ownership with --unsigned or --changeset for production deployments.")
-}
-
-func isProductionTarget(target string) bool {
-	normalized := strings.ToLower(strings.TrimSpace(target))
-	return strings.Contains(normalized, "production")
+	ui.Warning("Workflow deploy is using private-key ownership. Use multi-sig ownership with --unsigned or --changeset for more secure deployments.")
 }

--- a/cmd/workflow/deploy/deploy_test.go
+++ b/cmd/workflow/deploy/deploy_test.go
@@ -865,7 +865,7 @@ func TestWarnExistingPausedWorkflowUpdate(t *testing.T) {
 	})
 }
 
-func TestWarnIfProductionWorkflowWithoutMultisig(t *testing.T) {
+func TestWarnIfDeployingWithPrivateKey(t *testing.T) {
 	// Do not use t.Parallel: stderr redirection uses package-global os.Stderr.
 
 	captureStderr := func(f func()) string {
@@ -887,7 +887,7 @@ func TestWarnIfProductionWorkflowWithoutMultisig(t *testing.T) {
 		return buf.String()
 	}
 
-	newWarningHandler := func(target, ownerType string) *handler {
+	newWarningHandler := func(ownerType string) *handler {
 		s := createTestSettings(
 			chainsim.TestAddress,
 			ownerType,
@@ -895,54 +895,30 @@ func TestWarnIfProductionWorkflowWithoutMultisig(t *testing.T) {
 			"testdata/basic_workflow/main.go",
 			"",
 		)
-		s.User.TargetName = target
 		return &handler{settings: s}
 	}
 
-	t.Run("prints warning for production EOA deploy", func(t *testing.T) {
-		h := newWarningHandler("production-settings", constants.WorkflowOwnerTypeEOA)
-		out := captureStderr(h.warnIfProductionWorkflowWithoutMultisig)
+	t.Run("prints warning for EOA deploy", func(t *testing.T) {
+		h := newWarningHandler(constants.WorkflowOwnerTypeEOA)
+		out := captureStderr(h.warnIfDeployingWithPrivateKey)
 
-		assert.Contains(t, out, "Production workflow deploy is using private-key ownership")
+		assert.Contains(t, out, "Workflow deploy is using private-key ownership")
 		assert.Contains(t, out, "--unsigned")
 	})
 
-	t.Run("does not warn for staging EOA deploy", func(t *testing.T) {
-		h := newWarningHandler("staging-settings", constants.WorkflowOwnerTypeEOA)
-		out := captureStderr(h.warnIfProductionWorkflowWithoutMultisig)
+	t.Run("does not warn for MSIG deploy", func(t *testing.T) {
+		h := newWarningHandler(constants.WorkflowOwnerTypeMSIG)
+		out := captureStderr(h.warnIfDeployingWithPrivateKey)
 
 		assert.Empty(t, strings.TrimSpace(out))
 	})
 
-	t.Run("does not warn for production MSIG deploy", func(t *testing.T) {
-		h := newWarningHandler("production-settings", constants.WorkflowOwnerTypeMSIG)
-		out := captureStderr(h.warnIfProductionWorkflowWithoutMultisig)
+	t.Run("does not warn for org-derived deploy", func(t *testing.T) {
+		h := newWarningHandler(constants.WorkflowOwnerTypeOrgDerived)
+		out := captureStderr(h.warnIfDeployingWithPrivateKey)
 
 		assert.Empty(t, strings.TrimSpace(out))
 	})
-}
-
-func TestIsProductionTarget(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		target string
-		want   bool
-	}{
-		{target: "production", want: true},
-		{target: "production-settings", want: true},
-		{target: "production-jovay", want: true},
-		{target: "jovay-production", want: true},
-		{target: "staging-settings", want: false},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.target, func(t *testing.T) {
-			t.Parallel()
-
-			assert.Equal(t, tt.want, isProductionTarget(tt.target))
-		})
-	}
 }
 
 func TestCheckUserDonLimitBeforeDeploy(t *testing.T) {

--- a/cmd/workflow/deploy/deploy_test.go
+++ b/cmd/workflow/deploy/deploy_test.go
@@ -19,6 +19,7 @@ import (
 
 	workflow_registry_v2_wrapper "github.com/smartcontractkit/chainlink-evm/gethwrappers/workflow/generated/workflow_registry_wrapper_v2"
 
+	"github.com/smartcontractkit/cre-cli/internal/constants"
 	"github.com/smartcontractkit/cre-cli/internal/testutil/chainsim"
 	"github.com/smartcontractkit/cre-cli/internal/validation"
 )
@@ -862,6 +863,86 @@ func TestWarnExistingPausedWorkflowUpdate(t *testing.T) {
 		assert.Contains(t, out, "Your workflow is paused")
 		assert.Contains(t, out, "and has been updated")
 	})
+}
+
+func TestWarnIfProductionWorkflowWithoutMultisig(t *testing.T) {
+	// Do not use t.Parallel: stderr redirection uses package-global os.Stderr.
+
+	captureStderr := func(f func()) string {
+		t.Helper()
+		old := os.Stderr
+		r, w, err := os.Pipe()
+		require.NoError(t, err)
+		os.Stderr = w
+
+		f()
+
+		require.NoError(t, w.Close())
+		os.Stderr = old
+
+		var buf bytes.Buffer
+		_, copyErr := io.Copy(&buf, r)
+		require.NoError(t, copyErr)
+		require.NoError(t, r.Close())
+		return buf.String()
+	}
+
+	newWarningHandler := func(target, ownerType string) *handler {
+		s := createTestSettings(
+			chainsim.TestAddress,
+			ownerType,
+			"test_workflow",
+			"testdata/basic_workflow/main.go",
+			"",
+		)
+		s.User.TargetName = target
+		return &handler{settings: s}
+	}
+
+	t.Run("prints warning for production EOA deploy", func(t *testing.T) {
+		h := newWarningHandler("production-settings", constants.WorkflowOwnerTypeEOA)
+		out := captureStderr(h.warnIfProductionWorkflowWithoutMultisig)
+
+		assert.Contains(t, out, "Production workflow deploy is using private-key ownership")
+		assert.Contains(t, out, "--unsigned")
+	})
+
+	t.Run("does not warn for staging EOA deploy", func(t *testing.T) {
+		h := newWarningHandler("staging-settings", constants.WorkflowOwnerTypeEOA)
+		out := captureStderr(h.warnIfProductionWorkflowWithoutMultisig)
+
+		assert.Empty(t, strings.TrimSpace(out))
+	})
+
+	t.Run("does not warn for production MSIG deploy", func(t *testing.T) {
+		h := newWarningHandler("production-settings", constants.WorkflowOwnerTypeMSIG)
+		out := captureStderr(h.warnIfProductionWorkflowWithoutMultisig)
+
+		assert.Empty(t, strings.TrimSpace(out))
+	})
+}
+
+func TestIsProductionTarget(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		target string
+		want   bool
+	}{
+		{target: "production", want: true},
+		{target: "production-settings", want: true},
+		{target: "production-jovay", want: true},
+		{target: "jovay-production", want: true},
+		{target: "staging-settings", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.target, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tt.want, isProductionTarget(tt.target))
+		})
+	}
 }
 
 func TestCheckUserDonLimitBeforeDeploy(t *testing.T) {


### PR DESCRIPTION
This pull request introduces a warning to ensure safer production deployments by alerting users when deploying with private-key (EOA) ownership instead of recommended multi-sig ownership.

**Production deployment safety improvements:**

* Added `warnIfProductionWorkflowWithoutMultisig` to the `handler` in `deploy.go`, which warns users if a production workflow is being deployed using EOA (private-key) ownership, recommending the use of multi-sig ownership for production. 