### PR TITLE
Fail closed on unparseable semver during self-update

### DIFF
--- a/cmd/update/update.go
+++ b/cmd/update/update.go
@@ -300,8 +300,9 @@ func replaceSelf(newBin string) error {
 	return os.Rename(newBin, self)
 }
 
-// Run accepts the currentVersion string
-func Run(currentVersion string) error {
+// Run accepts the currentVersion string and a force flag that overrides the
+// fail-closed behavior when versions cannot be compared.
+func Run(currentVersion string, force bool) error {
 	spinner := ui.NewSpinner()
 	spinner.Start("Checking for updates...")
 
@@ -322,9 +323,17 @@ func Run(currentVersion string) error {
 	latestSemVer, errLatest := semver.NewVersion(cleanedLatest)
 
 	if errCurrent != nil || errLatest != nil {
-		// If we can't parse either version, fall back to just updating.
+		// If we can't parse either version, fail closed to avoid an unintended
+		// downgrade or version jump, unless the user explicitly opts in with --force.
 		spinner.Stop()
-		ui.Warning(fmt.Sprintf("Could not compare versions (current: '%s', latest: '%s'). Proceeding with update.", cleanedCurrent, cleanedLatest))
+		if !force {
+			ui.ErrorWithSuggestions(
+				fmt.Sprintf("Could not compare versions (current: '%s', latest: '%s'); refusing to update to avoid an unintended downgrade or version jump.", cleanedCurrent, cleanedLatest),
+				[]string{"Re-run with --force to update anyway"},
+			)
+			return fmt.Errorf("unable to parse version for comparison (current: %q, latest: %q)", cleanedCurrent, cleanedLatest)
+		}
+		ui.Warning(fmt.Sprintf("Could not compare versions (current: '%s', latest: '%s'). Proceeding due to --force.", cleanedCurrent, cleanedLatest))
 		spinner.Start("Updating...")
 	} else {
 		// Compare versions
@@ -411,6 +420,7 @@ func Run(currentVersion string) error {
 
 // New is modified to use the version package
 func New(_ *runtime.Context) *cobra.Command { // <-- No longer uses rt
+	var force bool
 	var versionCmd = &cobra.Command{
 		Use:   "update",
 		Short: "Update the cre CLI to the latest version",
@@ -422,9 +432,12 @@ On Linux, the signature is verified using GPG.
 On macOS, the signature is verified using codesign.
 On Windows, the signature is verified using Authenticode.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return Run(version.Version)
+			return Run(version.Version, force)
 		},
 	}
+
+	versionCmd.Flags().BoolVarP(&force, "force", "f", false,
+		"Proceed with the update even if the current or latest version cannot be parsed for comparison")
 
 	return versionCmd
 }

--- a/cmd/update/update_test.go
+++ b/cmd/update/update_test.go
@@ -48,9 +48,69 @@ func TestRun_abortsWhenSignatureVerificationFails(t *testing.T) {
 		)
 	}
 
-	err = Run("version v0.0.1")
+	err = Run("version v0.0.1", false)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "release signature verification failed")
+}
+
+func TestRun_failsClosedWhenLatestVersionUnparseable(t *testing.T) {
+	httpmock.ActivateNonDefault(httpClient)
+	t.Cleanup(httpmock.DeactivateAndReset)
+
+	latestURL := "https://api.github.com/repos/smartcontractkit/cre-cli/releases/latest"
+	httpmock.RegisterResponder("GET", latestURL,
+		func(_ *http.Request) (*http.Response, error) {
+			body, _ := json.Marshal(releaseInfo{TagName: "garbage-tag"})
+			return httpmock.NewBytesResponse(http.StatusOK, body), nil
+		},
+	)
+
+	err := Run("version v0.0.1", false)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unable to parse version")
+
+	// No asset download should have been attempted: only the latest-release
+	// endpoint should have been hit.
+	callCounts := httpmock.GetCallCountInfo()
+	require.Equal(t, 1, callCounts["GET "+latestURL])
+	require.Len(t, callCounts, 1)
+}
+
+func TestRun_failsClosedWhenCurrentVersionUnparseable(t *testing.T) {
+	httpmock.ActivateNonDefault(httpClient)
+	t.Cleanup(httpmock.DeactivateAndReset)
+
+	latestURL := "https://api.github.com/repos/smartcontractkit/cre-cli/releases/latest"
+	httpmock.RegisterResponder("GET", latestURL,
+		func(_ *http.Request) (*http.Response, error) {
+			body, _ := json.Marshal(releaseInfo{TagName: "v9.9.9"})
+			return httpmock.NewBytesResponse(http.StatusOK, body), nil
+		},
+	)
+
+	err := Run("not-a-version", false)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unable to parse version")
+}
+
+func TestRun_forceBypassesUnparseableVersionCheck(t *testing.T) {
+	httpmock.ActivateNonDefault(httpClient)
+	t.Cleanup(httpmock.DeactivateAndReset)
+
+	latestURL := "https://api.github.com/repos/smartcontractkit/cre-cli/releases/latest"
+	httpmock.RegisterResponder("GET", latestURL,
+		func(_ *http.Request) (*http.Response, error) {
+			body, _ := json.Marshal(releaseInfo{TagName: "garbage-tag"})
+			return httpmock.NewBytesResponse(http.StatusOK, body), nil
+		},
+	)
+
+	// With --force, the version-comparison guard is bypassed and execution
+	// proceeds into the download step, which fails against the unregistered
+	// asset URL. The important thing is that it is NOT the parse error.
+	err := Run("version v0.0.1", true)
+	require.Error(t, err)
+	require.NotContains(t, err.Error(), "unable to parse version")
 }
 
 func createTestArchiveBytes(t *testing.T, asset, tag, platform, archName string, content []byte) []byte {

--- a/docs/cre_update.md
+++ b/docs/cre_update.md
@@ -19,7 +19,8 @@ cre update [optional flags]
 ### Options
 
 ```
-  -h, --help   help for update
+  -f, --force   Proceed with the update even if the current or latest version cannot be parsed for comparison
+  -h, --help    help for update
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
[DEVSVCS-5289](https://smartcontract-it.atlassian.net/browse/DEVSVCS-5289)
## Fail closed on unparseable semver during self-update

**Problem**: 
cre update previously proceeded with the update whenever it couldn't parse the current or latest version as semver (fail-open), allowing unintended downgrades or version jumps. Flagged by security review.

**Fix:**
- Run now fails closed when either version is unparseable, returning an error and suggesting --force.
- Added a --force/-f flag to restore the warn-and-proceed behavior when explicitly requested.
- Normal downgrade/already-latest short-circuit is unchanged when both versions parse.
- Tests: added coverage for fail-closed on unparseable latest (asserting no download attempted), unparseable current, and --force bypass.