### PR TITLE
Harden install-script tag resolution and bootstrap supply chain

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -409,6 +409,9 @@ jobs:
       contents: write
       id-token: write
     steps:
+      - name: Checkout the repo
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # actions/checkout@v4.2.2
+
       - name: Download Build Artifacts for linux/amd64
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # actions/download-artifact@v4.1.8
         with:
@@ -476,6 +479,10 @@ jobs:
 
             # Windows amd64 zip
             echo "cre_${VERSION}_windows_amd64.zip: $(shasum -a 256 ./windows_amd64/cre_${VERSION}_windows_amd64.zip | awk '{print $1}')"
+
+            # Bootstrap install scripts
+            echo "install.sh: $(shasum -a 256 ./install/install.sh | awk '{print $1}')"
+            echo "install.ps1: $(shasum -a 256 ./install/install.ps1 | awk '{print $1}')"
           } >> checksums.txt
 
           # Display checksums for verification
@@ -612,6 +619,28 @@ jobs:
           asset_path: ./windows_amd64/cre_${{ github.ref_name }}_windows_amd64.zip
           asset_name: cre_windows_amd64.zip
           asset_content_type: application/octet-stream
+
+      # Upload bootstrap install script (bash)
+      - name: Upload Release Asset for install.sh
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./install/install.sh
+          asset_name: install.sh
+          asset_content_type: text/x-shellscript
+
+      # Upload bootstrap install script (PowerShell)
+      - name: Upload Release Asset for install.ps1
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./install/install.ps1
+          asset_name: install.ps1
+          asset_content_type: text/plain
 
       # Upload Checksums
       - name: Upload Checksums

--- a/.github/workflows/pull-request-main.yml
+++ b/.github/workflows/pull-request-main.yml
@@ -51,6 +51,9 @@ jobs:
       - name: Verify install.sh linux asset suffix helpers
         run: bash install/linux_asset_suffix_test.sh
 
+      - name: Verify install.sh tag parsing helpers
+        run: bash install/tag_parse_test.sh
+
   ci-test-unit:
     runs-on: ubuntu-latest
     permissions:

--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ A Go/Cobra-based command-line tool for building, testing, and managing Chainlink
 
 ## Installation
 
+> **CRE end users:** to install the released CLI (with instructions for verifying
+> the bootstrap script against published checksums), see [install/README.md](install/README.md).
+> The steps below are for building the CLI from source as a developer.
+
 1. Clone the repository:
 
     ```bash

--- a/install/README.md
+++ b/install/README.md
@@ -1,0 +1,82 @@
+# Installing the CRE CLI
+
+This directory holds the bootstrap installers for the `cre` CLI:
+
+- `install.sh` — Linux and macOS (bash)
+- `install.ps1` — Windows (PowerShell)
+
+## Quick install
+
+**Linux / macOS**
+
+```bash
+curl -sSL https://app.chain.link/install.sh | bash
+```
+
+**Windows (PowerShell)**
+
+```powershell
+irm https://app.chain.link/install.ps1 | iex
+```
+
+This downloads the latest release, verifies the release **binary** signature
+(GPG on Linux, `codesign` on macOS, Authenticode on Windows), and installs it.
+
+## Verify the install script before running it
+
+Piping a script straight into `bash`/`iex` runs it sight-unseen. If you would
+rather verify the bootstrap script itself first, every GitHub release publishes
+`install.sh`, `install.ps1`, and a `checksums.txt` containing their SHA-256
+digests. Download, verify, inspect, then run the local copy.
+
+**Linux / macOS**
+
+```bash
+tag=$(curl -fsSL https://api.github.com/repos/smartcontractkit/cre-cli/releases/latest \
+  | grep -Eo '"tag_name":\s*"[^"]+"' | head -n1 | grep -Eo 'v[0-9][^"]*')
+base="https://github.com/smartcontractkit/cre-cli/releases/download/$tag"
+
+curl -fsSL "$base/install.sh"    -o install.sh
+curl -fsSL "$base/checksums.txt" -o checksums.txt
+
+# Compare the published digest against the file you downloaded.
+expected=$(grep '^install.sh:' checksums.txt | awk '{print $2}')
+actual=$(shasum -a 256 install.sh | awk '{print $1}')
+[ "$expected" = "$actual" ] && echo "OK: checksum matches" || { echo "MISMATCH"; exit 1; }
+
+# Inspect, then run the verified local copy.
+less install.sh
+bash install.sh
+```
+
+**Windows (PowerShell)**
+
+```powershell
+$tag  = (Invoke-RestMethod https://api.github.com/repos/smartcontractkit/cre-cli/releases/latest).tag_name
+$base = "https://github.com/smartcontractkit/cre-cli/releases/download/$tag"
+
+Invoke-WebRequest "$base/install.ps1"    -OutFile install.ps1
+Invoke-WebRequest "$base/checksums.txt"  -OutFile checksums.txt
+
+$expected = ((Select-String '^install.ps1:' checksums.txt).Line -split '\s+')[1]
+$actual   = (Get-FileHash -Algorithm SHA256 install.ps1).Hash.ToLower()
+if ($expected -eq $actual) { "OK: checksum matches" } else { throw "MISMATCH" }
+
+# Inspect, then run the verified local copy.
+Get-Content install.ps1
+.\install.ps1
+```
+
+> **Note:** `checksums.txt` uses a `filename: sha256` format (not the
+> `sha256  filename` layout that `sha256sum -c` expects), so verify by comparing
+> the digest as shown above rather than piping into `sha256sum -c`.
+
+## What is verified, and what is not
+
+- **Release binaries** are cryptographically verified by the install script:
+  GPG signature (Linux, against the key embedded in `install.sh` /
+  `install/public_key.asc`), Apple `codesign` (macOS), and Authenticode
+  (Windows).
+- **The bootstrap scripts** are served from `app.chain.link`. Verifying them
+  against the release-published `checksums.txt` (above) confirms they match the
+  reviewed source for a given release tag.

--- a/install/install.ps1
+++ b/install/install.ps1
@@ -132,6 +132,19 @@ function Test-ReleaseAuthenticode {
     }
 }
 
+function Test-ValidTag {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Tag
+    )
+
+    # Fail closed on anything that is not a plausible release tag
+    # (vMAJOR.MINOR.PATCH with optional pre-release/build suffix).
+    if ($Tag -notmatch '^v?\d+\.\d+\.\d+([-.+][0-9A-Za-z.-]+)*$') {
+        Fail "Refusing to install: invalid release tag '$Tag'."
+    }
+}
+
 function Test-UnsafeZipEntry {
     param(
         [Parameter(Mandatory = $true)]
@@ -214,6 +227,7 @@ try {
     if (-not $LatestTag) {
         throw "Could not determine the latest release tag from GitHub."
     }
+    Test-ValidTag $LatestTag
     Write-Host "Latest version is $LatestTag."
 
     # 3. Construct Download URL and Destination Path

--- a/install/install.sh
+++ b/install/install.sh
@@ -241,6 +241,25 @@ linux_asset_suffix() {
   fi
 }
 
+# Extract the tag_name from a GitHub release JSON payload. Prefer jq for real
+# structured parsing; fall back to an anchored sed that works on minified JSON.
+extract_tag_name() {
+  local json=$1
+  if command -v jq >/dev/null 2>&1; then
+    printf '%s' "$json" | jq -r '.tag_name // empty'
+  else
+    printf '%s' "$json" |
+      sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' |
+      head -n1
+  fi
+}
+
+# Fail closed on anything that is not a plausible release tag (vMAJOR.MINOR.PATCH
+# with optional pre-release/build suffix).
+is_valid_tag() {
+  printf '%s' "$1" | grep -Eq '^v?[0-9]+\.[0-9]+\.[0-9]+([-.+][0-9A-Za-z.-]+)*$'
+}
+
 tildify() {
     if [[ $1 = $HOME/* ]]; then
         local replacement=\~/
@@ -355,15 +374,22 @@ fi
 
 # 3. Determine the Latest Version from GitHub Releases
 check_command "curl"
-LATEST_TAG=$(curl -s "https://api.github.com/repos/$github_repo/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
+API_RESPONSE=$(curl -fsSL "https://api.github.com/repos/$github_repo/releases/latest") ||
+  fail "Could not reach GitHub to determine the latest release version."
+LATEST_TAG=$(extract_tag_name "$API_RESPONSE")
 if [ -z "$LATEST_TAG" ]; then
   fail "Could not fetch the latest release version from GitHub."
 fi
 
-if [[ $# = 0 ]]; then
-  echo "Installing $cli_name version $LATEST_TAG for $PLATFORM/$ARCH_NAME..."
-else
+# Allow an explicit tag override (existing behavior), but validate it too.
+if [[ $# -ne 0 ]]; then
   LATEST_TAG=$1
+fi
+
+is_valid_tag "$LATEST_TAG" || fail "Refusing to install: invalid release tag '$LATEST_TAG'."
+
+if [[ $# -eq 0 ]]; then
+  echo "Installing $cli_name version $LATEST_TAG for $PLATFORM/$ARCH_NAME..."
 fi
 
 # 4. Construct Download URL and Download asset

--- a/install/tag_parse_test.sh
+++ b/install/tag_parse_test.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+install_sh="$repo_root/install/install.sh"
+failures=0
+
+pass() { echo "PASS: $1"; }
+fail_test() { echo "FAIL: $1"; failures=$((failures + 1)); }
+
+# Source the tag-parsing helpers (extract_tag_name / is_valid_tag) from install.sh.
+# shellcheck disable=SC1090
+source <(sed -n '244,261p' "$install_sh")
+
+assert_extract() {
+  local name=$1
+  local json=$2
+  local want=$3
+  local got
+
+  got=$(extract_tag_name "$json")
+  if [ "$got" = "$want" ]; then
+    pass "$name"
+  else
+    fail_test "$name (got '$got', want '$want')"
+  fi
+}
+
+assert_valid() {
+  local name=$1
+  local tag=$2
+
+  if is_valid_tag "$tag"; then
+    pass "$name"
+  else
+    fail_test "$name (expected valid, got rejected)"
+  fi
+}
+
+assert_invalid() {
+  local name=$1
+  local tag=$2
+
+  if is_valid_tag "$tag"; then
+    fail_test "$name (expected rejected, got valid)"
+  else
+    pass "$name"
+  fi
+}
+
+# --- extract_tag_name ---
+
+assert_extract "pretty-printed JSON" \
+  $'{\n  "tag_name": "v1.2.3",\n  "name": "Release v1.2.3"\n}' \
+  "v1.2.3"
+
+# Minified single-line JSON: the case the old grep|sed parser got wrong.
+assert_extract "minified JSON" \
+  '{"url":"https://example.com","tag_name":"v1.2.3","name":"other"}' \
+  "v1.2.3"
+
+assert_extract "tag_name not first field" \
+  '{"id":42,"draft":false,"tag_name":"v4.5.6"}' \
+  "v4.5.6"
+
+# --- is_valid_tag ---
+
+assert_valid "plain semver with v" "v1.2.3"
+assert_valid "semver without v" "1.2.3"
+assert_valid "pre-release suffix" "v1.2.3-rc.1"
+assert_valid "build metadata suffix" "v1.2.3+build.7"
+
+assert_invalid "empty string" ""
+assert_invalid "the word latest" "latest"
+assert_invalid "incomplete version" "v1"
+assert_invalid "path traversal" "../../evil"
+assert_invalid "command substitution" '$(rm -rf /)'
+assert_invalid "url injection" "v1.2.3/../../etc"
+
+if [ "$failures" -ne 0 ]; then
+  echo "$failures tag parse test(s) failed" >&2
+  exit 1
+fi
+
+echo "All tag parse tests passed."


### PR DESCRIPTION
[DEVSVCS-5290](https://smartcontract-it.atlassian.net/browse/DEVSVCS-5290)
## Harden install-script tag resolution and bootstrap supply chain

**Tag resolution & validation**
- `install.sh`: replaced fragile `grep | sed` (broke on minified JSON) with `extract_tag_name` — prefers `jq`, falls back to an anchored `sed` (no new hard dependency). Added `is_valid_tag` that fails closed on non-semver tags, applied to both the fetched tag and user-supplied overrides. Fetch now uses `curl -fsSL`.
- `install.ps1`: added `Test-ValidTag` on the resolved tag before building the download URL.

**Bootstrap verification**
- Release pipeline now publishes `install.sh`, `install.ps1`, and their SHA-256 in `checksums.txt` as release assets.
- New `install/README.md` documents a download → verify → inspect → run flow (bash + PowerShell); main README points end users to it.

**Tests/CI**
- New `install/tag_parse_test.sh` (pretty/minified JSON, valid/invalid tags) wired into the `ci-lint-misc` job.

**Verification:** new + existing install tests pass; `bash -n` and `actionlint` clean (only pre-existing warnings).

**Follow-ups:** `app.chain.link` still hosts the scripts out-of-band — this establishes the verifiable source of truth, hosting parity is separate.